### PR TITLE
feat: simulation replay functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,22 @@
       {
         "command": "stellarSuite.importBackups",
         "title": "Stellar Suite: Import Backups"
+      },
+      {
+        "command": "stellarSuite.replaySimulation",
+        "title": "Stellar Suite: Replay Simulation"
+      },
+      {
+        "command": "stellarSuite.replayWithModifications",
+        "title": "Stellar Suite: Replay Simulation with Modifications"
+      },
+      {
+        "command": "stellarSuite.batchReplaySimulations",
+        "title": "Stellar Suite: Batch Replay Simulations"
+      },
+      {
+        "command": "stellarSuite.exportReplayResults",
+        "title": "Stellar Suite: Export Replay Results"
       }
     ],
     "menus": {
@@ -194,7 +210,7 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
-    "test": "npm run test:cli-errors && npm run test:version-tracker && npm run test:state-validation && npm run test:cargo-metadata && npm run test:simulation-history && npm run test:cli-validation && npm run test:compilation-status && npm run test:state-backup && npm run test:sidebar-export-import",
+    "test": "npm run test:cli-errors && npm run test:version-tracker && npm run test:state-validation && npm run test:cargo-metadata && npm run test:simulation-history && npm run test:cli-validation && npm run test:compilation-status && npm run test:state-backup && npm run test:sidebar-export-import && npm run test:simulation-replay",
     "test:cli-errors": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/utils/cliErrorParser.ts src/test/cliErrorParser.test.ts && node out-test/test/cliErrorParser.test.js",
     "test:version-tracker": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/utils/versionParser.ts src/services/contractVersionTracker.ts src/test/versionTracker.test.ts && node out-test/test/versionTracker.test.js",
     "test:state-validation": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/utils/stateIntegrity.ts src/services/stateValidationService.ts src/test/stateValidationService.test.ts && node out-test/test/stateValidationService.test.js",
@@ -202,8 +218,9 @@
     "test:compilation-status": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/types/compilationStatus.ts src/services/compilationStatusMonitor.ts src/test/compilationStatus.test.ts && node out-test/test/compilationStatus.test.js",
     "test:cli-validation": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/types/cliValidation.ts src/services/parameterValidator.ts src/services/environmentValidator.ts src/services/fileValidator.ts src/services/networkValidator.ts src/services/cliValidationService.ts src/services/preFlightCheckService.ts src/test/cliValidation.test.ts && node out-test/test/cliValidation.test.js",
     "test:simulation-history": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/services/simulationHistoryService.ts src/test/simulationHistory.test.ts && node out-test/test/simulationHistory.test.js",
-    "test:state-backup": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/services/stateBackupService.ts src/test/stateBackup.test.ts && node out-test/test/stateBackup.test.js"
-    "test:sidebar-export-import": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/types/sidebarExport.ts src/services/sidebarExportService.ts src/services/sidebarImportService.ts src/test/sidebarExportImport.test.ts && node out-test/test/sidebarExportImport.test.js"
+    "test:state-backup": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/services/stateBackupService.ts src/test/stateBackup.test.ts && node out-test/test/stateBackup.test.js",
+    "test:sidebar-export-import": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/types/sidebarExport.ts src/services/sidebarExportService.ts src/services/sidebarImportService.ts src/test/sidebarExportImport.test.ts && node out-test/test/sidebarExportImport.test.js",
+    "test:simulation-replay": "tsc --module commonjs --target ES2020 --lib ES2020,DOM --esModuleInterop --skipLibCheck --rootDir src --outDir out-test src/services/simulationHistoryService.ts src/services/simulationReplayService.ts src/test/simulationReplay.test.ts && node out-test/test/simulationReplay.test.js"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/commands/replayCommands.ts
+++ b/src/commands/replayCommands.ts
@@ -1,0 +1,476 @@
+// ============================================================
+// src/commands/replayCommands.ts
+// Command palette commands for simulation replay functionality.
+// ============================================================
+
+import * as vscode from 'vscode';
+import { SimulationHistoryService, SimulationHistoryEntry } from '../services/simulationHistoryService';
+import {
+    SimulationReplayService,
+    ReplayOverrides,
+    ReplayParameters,
+    ReplayResult,
+    SimulationExecutor,
+} from '../services/simulationReplayService';
+import { SorobanCliService } from '../services/sorobanCliService';
+import { RpcService } from '../services/rpcService';
+import { SimulationPanel } from '../ui/simulationPanel';
+import { SidebarViewProvider } from '../ui/sidebarView';
+import { resolveCliConfigurationForCommand } from '../services/cliConfigurationVscode';
+
+/**
+ * Register all simulation replay commands with the extension context.
+ */
+export function registerReplayCommands(
+    context: vscode.ExtensionContext,
+    historyService: SimulationHistoryService,
+    replayService: SimulationReplayService,
+    sidebarProvider?: SidebarViewProvider
+): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'stellarSuite.replaySimulation',
+            () => replayFromHistory(context, historyService, replayService, sidebarProvider)
+        ),
+        vscode.commands.registerCommand(
+            'stellarSuite.replayWithModifications',
+            () => replayWithModifications(context, historyService, replayService, sidebarProvider)
+        ),
+        vscode.commands.registerCommand(
+            'stellarSuite.batchReplaySimulations',
+            () => batchReplaySimulations(context, historyService, replayService, sidebarProvider)
+        ),
+        vscode.commands.registerCommand(
+            'stellarSuite.exportReplayResults',
+            () => exportReplayResults(replayService)
+        ),
+    );
+}
+
+// ── Shared state for last batch results ──────────────────────
+
+let lastReplayResults: ReplayResult[] = [];
+
+// ── Command implementations ──────────────────────────────────
+
+async function replayFromHistory(
+    context: vscode.ExtensionContext,
+    historyService: SimulationHistoryService,
+    replayService: SimulationReplayService,
+    sidebarProvider?: SidebarViewProvider
+): Promise<void> {
+    const entry = await pickHistoryEntry(historyService, 'Select a simulation to replay');
+    if (!entry) { return; }
+
+    const executor = await buildExecutor(context);
+    if (!executor) { return; }
+
+    await executeReplay(context, replayService, entry, executor, {}, sidebarProvider);
+}
+
+async function replayWithModifications(
+    context: vscode.ExtensionContext,
+    historyService: SimulationHistoryService,
+    replayService: SimulationReplayService,
+    sidebarProvider?: SidebarViewProvider
+): Promise<void> {
+    const entry = await pickHistoryEntry(historyService, 'Select a simulation to replay with modifications');
+    if (!entry) { return; }
+
+    const overrides = await collectOverrides(entry);
+    if (!overrides) { return; }
+
+    const executor = await buildExecutor(context);
+    if (!executor) { return; }
+
+    await executeReplay(context, replayService, entry, executor, overrides, sidebarProvider);
+}
+
+async function batchReplaySimulations(
+    context: vscode.ExtensionContext,
+    historyService: SimulationHistoryService,
+    replayService: SimulationReplayService,
+    sidebarProvider?: SidebarViewProvider
+): Promise<void> {
+    const entries = historyService.queryHistory({ limit: 50 });
+    if (entries.length === 0) {
+        vscode.window.showInformationMessage('Stellar Suite: No simulation history to replay.');
+        return;
+    }
+
+    const items = entries.map(entry => ({
+        label: `$(${entry.outcome === 'success' ? 'check' : 'error'}) ${entry.functionName}()`,
+        description: `${entry.contractId.slice(0, 8)}…${entry.contractId.slice(-4)}`,
+        detail: `${new Date(entry.timestamp).toLocaleString()} · ${entry.network} · ${entry.outcome}`,
+        entry,
+        picked: false,
+    }));
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select simulations to replay (multi-select)',
+        canPickMany: true,
+        matchOnDescription: true,
+        matchOnDetail: true,
+    });
+
+    if (!selected || selected.length === 0) { return; }
+
+    const confirm = await vscode.window.showWarningMessage(
+        `Replay ${selected.length} simulation(s)?`,
+        { modal: false },
+        'Replay All'
+    );
+
+    if (confirm !== 'Replay All') { return; }
+
+    const executor = await buildExecutor(context);
+    if (!executor) { return; }
+
+    const entryIds = selected.map(s => s.entry.id);
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Replaying Simulations',
+            cancellable: false,
+        },
+        async (progress) => {
+            progress.report({ increment: 0, message: `0/${entryIds.length} completed` });
+
+            const batchResult = await replayService.batchReplay(entryIds, executor);
+
+            lastReplayResults = batchResult.results;
+
+            progress.report({ increment: 100, message: 'Complete' });
+
+            const summary = [
+                `${batchResult.succeeded} succeeded`,
+                `${batchResult.failed} failed`,
+                batchResult.skipped > 0 ? `${batchResult.skipped} skipped` : '',
+            ].filter(Boolean).join(', ');
+
+            const outcomeChanges = batchResult.results.filter(r => r.comparison.outcomeChanged).length;
+            const changeNote = outcomeChanges > 0
+                ? ` (${outcomeChanges} outcome change${outcomeChanges > 1 ? 's' : ''})`
+                : '';
+
+            vscode.window.showInformationMessage(
+                `Stellar Suite: Batch replay complete — ${summary}${changeNote}`
+            );
+
+            // Update sidebar if available
+            if (sidebarProvider && batchResult.results.length > 0) {
+                sidebarProvider.refresh();
+            }
+        }
+    );
+}
+
+async function exportReplayResults(replayService: SimulationReplayService): Promise<void> {
+    if (lastReplayResults.length === 0) {
+        vscode.window.showInformationMessage(
+            'Stellar Suite: No replay results to export. Run a replay first.'
+        );
+        return;
+    }
+
+    const uri = await vscode.window.showSaveDialog({
+        defaultUri: vscode.Uri.file('simulation-replay-results.json'),
+        filters: { 'JSON Files': ['json'] },
+        title: 'Export Replay Results',
+    });
+
+    if (!uri) { return; }
+
+    try {
+        const data = replayService.exportReplayResults(lastReplayResults);
+        await vscode.workspace.fs.writeFile(uri, Buffer.from(data, 'utf-8'));
+        vscode.window.showInformationMessage(
+            `Stellar Suite: Exported ${lastReplayResults.length} replay results.`
+        );
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Stellar Suite: Export failed — ${msg}`);
+    }
+}
+
+// ── Shared helpers ───────────────────────────────────────────
+
+async function pickHistoryEntry(
+    historyService: SimulationHistoryService,
+    placeholder: string
+): Promise<SimulationHistoryEntry | undefined> {
+    const entries = historyService.queryHistory({ limit: 50 });
+    if (entries.length === 0) {
+        vscode.window.showInformationMessage('Stellar Suite: No simulation history available.');
+        return undefined;
+    }
+
+    const items = entries.map(entry => ({
+        label: `$(${entry.outcome === 'success' ? 'check' : 'error'}) ${entry.functionName}()`,
+        description: `${entry.contractId.slice(0, 8)}…${entry.contractId.slice(-4)}`,
+        detail: `${new Date(entry.timestamp).toLocaleString()} · ${entry.network} · ${entry.outcome}${entry.label ? ` · ${entry.label}` : ''}`,
+        entry,
+    }));
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: placeholder,
+        matchOnDescription: true,
+        matchOnDetail: true,
+    });
+
+    return selected?.entry;
+}
+
+async function collectOverrides(
+    entry: SimulationHistoryEntry
+): Promise<ReplayOverrides | undefined> {
+    const fieldChoices = [
+        { label: '$(symbol-key) Contract ID', value: 'contractId', current: entry.contractId },
+        { label: '$(symbol-method) Function Name', value: 'functionName', current: entry.functionName },
+        { label: '$(json) Arguments', value: 'args', current: JSON.stringify(entry.args) },
+        { label: '$(globe) Network', value: 'network', current: entry.network },
+        { label: '$(person) Source', value: 'source', current: entry.source },
+    ];
+
+    const fieldsToModify = await vscode.window.showQuickPick(
+        fieldChoices.map(f => ({
+            ...f,
+            description: `Current: ${truncate(f.current, 40)}`,
+            picked: false,
+        })),
+        {
+            placeHolder: 'Select parameters to modify (or press Enter to replay as-is)',
+            canPickMany: true,
+        }
+    );
+
+    // User cancelled
+    if (fieldsToModify === undefined) { return undefined; }
+
+    // No modifications selected — replay with original params
+    if (fieldsToModify.length === 0) { return {}; }
+
+    const overrides: ReplayOverrides = {};
+
+    for (const field of fieldsToModify) {
+        switch (field.value) {
+            case 'contractId': {
+                const value = await vscode.window.showInputBox({
+                    prompt: 'Enter new contract ID',
+                    value: entry.contractId,
+                    validateInput: (v) => {
+                        if (!v || v.trim().length === 0) { return 'Contract ID is required'; }
+                        if (!v.match(/^C[A-Z0-9]{55}$/)) {
+                            return 'Invalid contract ID format (should start with C and be 56 characters)';
+                        }
+                        return null;
+                    },
+                });
+                if (value === undefined) { return undefined; }
+                overrides.contractId = value;
+                break;
+            }
+            case 'functionName': {
+                const value = await vscode.window.showInputBox({
+                    prompt: 'Enter new function name',
+                    value: entry.functionName,
+                    validateInput: (v) => (!v || v.trim().length === 0) ? 'Function name is required' : null,
+                });
+                if (value === undefined) { return undefined; }
+                overrides.functionName = value;
+                break;
+            }
+            case 'args': {
+                const value = await vscode.window.showInputBox({
+                    prompt: 'Enter new arguments as JSON array',
+                    value: JSON.stringify(entry.args),
+                    validateInput: (v) => {
+                        try {
+                            const parsed = JSON.parse(v);
+                            if (!Array.isArray(parsed)) { return 'Arguments must be a JSON array'; }
+                            return null;
+                        } catch {
+                            return 'Invalid JSON';
+                        }
+                    },
+                });
+                if (value === undefined) { return undefined; }
+                overrides.args = JSON.parse(value);
+                break;
+            }
+            case 'network': {
+                const value = await vscode.window.showInputBox({
+                    prompt: 'Enter new network',
+                    value: entry.network,
+                    validateInput: (v) => (!v || v.trim().length === 0) ? 'Network is required' : null,
+                });
+                if (value === undefined) { return undefined; }
+                overrides.network = value.trim();
+                break;
+            }
+            case 'source': {
+                const value = await vscode.window.showInputBox({
+                    prompt: 'Enter new source identity',
+                    value: entry.source,
+                    validateInput: (v) => (!v || v.trim().length === 0) ? 'Source is required' : null,
+                });
+                if (value === undefined) { return undefined; }
+                overrides.source = value.trim();
+                break;
+            }
+        }
+    }
+
+    return overrides;
+}
+
+async function buildExecutor(
+    context: vscode.ExtensionContext
+): Promise<SimulationExecutor | undefined> {
+    const resolvedCliConfig = await resolveCliConfigurationForCommand(context);
+    if (!resolvedCliConfig.validation.valid) {
+        vscode.window.showErrorMessage(
+            `CLI configuration is invalid: ${resolvedCliConfig.validation.errors.join(' ')}`
+        );
+        return undefined;
+    }
+
+    const config = resolvedCliConfig.configuration;
+
+    return async (params: ReplayParameters) => {
+        const startTime = Date.now();
+
+        if (params.method === 'cli' || config.useLocalCli) {
+            let actualCliPath = config.cliPath;
+            let cliService = new SorobanCliService(actualCliPath, params.source);
+            let cliAvailable = await cliService.isAvailable();
+
+            if (!cliAvailable && config.cliPath === 'stellar') {
+                const foundPath = await SorobanCliService.findCliPath();
+                if (foundPath) {
+                    actualCliPath = foundPath;
+                    cliService = new SorobanCliService(actualCliPath, params.source);
+                    cliAvailable = await cliService.isAvailable();
+                }
+            }
+
+            if (!cliAvailable) {
+                return {
+                    success: false,
+                    error: `Stellar CLI not found at "${config.cliPath}".`,
+                    durationMs: Date.now() - startTime,
+                };
+            }
+
+            const result = await cliService.simulateTransaction(
+                params.contractId,
+                params.functionName,
+                params.args as any[],
+                params.network
+            );
+
+            return {
+                success: result.success,
+                result: result.result,
+                error: result.error,
+                errorType: result.errorType,
+                resourceUsage: result.resourceUsage,
+                durationMs: Date.now() - startTime,
+            };
+        } else {
+            const rpcService = new RpcService(config.rpcUrl);
+            const result = await rpcService.simulateTransaction(
+                params.contractId,
+                params.functionName,
+                params.args as any[]
+            );
+
+            return {
+                success: result.success,
+                result: result.result,
+                error: result.error,
+                errorType: result.errorType,
+                resourceUsage: result.resourceUsage,
+                durationMs: Date.now() - startTime,
+            };
+        }
+    };
+}
+
+async function executeReplay(
+    context: vscode.ExtensionContext,
+    replayService: SimulationReplayService,
+    entry: SimulationHistoryEntry,
+    executor: SimulationExecutor,
+    overrides: ReplayOverrides,
+    sidebarProvider?: SidebarViewProvider
+): Promise<void> {
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: 'Replaying Simulation',
+            cancellable: false,
+        },
+        async (progress) => {
+            progress.report({ increment: 0, message: 'Preparing replay...' });
+
+            let result: ReplayResult;
+            try {
+                progress.report({ increment: 30, message: 'Executing simulation...' });
+                result = await replayService.replaySimulation(entry.id, executor, overrides);
+            } catch (error) {
+                const msg = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Stellar Suite: Replay failed — ${msg}`);
+                return;
+            }
+
+            lastReplayResults = [result];
+            progress.report({ increment: 100, message: 'Complete' });
+
+            // Show results in simulation panel
+            const panel = SimulationPanel.createOrShow(context);
+            panel.updateResults(
+                {
+                    success: result.outcome === 'success',
+                    result: result.result,
+                    error: result.error,
+                },
+                result.parameters.contractId,
+                result.parameters.functionName,
+                result.parameters.args as any[]
+            );
+
+            // Update sidebar
+            if (sidebarProvider) {
+                sidebarProvider.showSimulationResult(result.parameters.contractId, {
+                    success: result.outcome === 'success',
+                    result: result.result,
+                    error: result.error,
+                });
+            }
+
+            // Show notification with comparison info
+            const changeInfo = result.comparison.outcomeChanged
+                ? ` (outcome changed: ${result.comparison.originalOutcome} → ${result.outcome})`
+                : '';
+            const modInfo = result.comparison.parametersModified
+                ? ` [modified: ${result.comparison.modifiedFields.join(', ')}]`
+                : '';
+
+            if (result.outcome === 'success') {
+                vscode.window.showInformationMessage(
+                    `Stellar Suite: Replay succeeded${changeInfo}${modInfo}`
+                );
+            } else {
+                vscode.window.showErrorMessage(
+                    `Stellar Suite: Replay failed${changeInfo}${modInfo} — ${result.error}`
+                );
+            }
+        }
+    );
+}
+
+function truncate(str: string, maxLen: number): string {
+    return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,10 @@ import { SimulationHistoryService } from "./services/simulationHistoryService";
 import { registerSimulationHistoryCommands } from "./commands/simulationHistoryCommands";
 import { CompilationStatusMonitor } from "./services/compilationStatusMonitor";
 import { CompilationStatusProvider } from "./ui/compilationStatusProvider";
-import { StateBackupService } from "./services/stateBackupService";
-import { registerBackupCommands } from "./commands/backupCommands";
+import { StateBackupService } from './services/stateBackupService';
+import { registerBackupCommands } from './commands/backupCommands';
+import { SimulationReplayService } from './services/simulationReplayService';
+import { registerReplayCommands } from './commands/replayCommands';
 
 let sidebarProvider: SidebarViewProvider | undefined;
 let groupService: ContractGroupService | undefined;
@@ -40,6 +42,7 @@ let simulationHistoryService: SimulationHistoryService | undefined;
 let compilationMonitor: CompilationStatusMonitor | undefined;
 let compilationStatusProvider: CompilationStatusProvider | undefined;
 let backupService: StateBackupService | undefined;
+let replayService: SimulationReplayService | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel("Stellar Suite");
@@ -241,7 +244,16 @@ export function activate(context: vscode.ExtensionContext) {
     if (backupService) {
       registerBackupCommands(context, backupService);
       outputChannel.appendLine(
-        "[Extension] Backup commands registered",
+        '[Extension] Backup commands registered',
+      );
+    }
+
+    // Initialize simulation replay service
+    if (simulationHistoryService) {
+      replayService = new SimulationReplayService(simulationHistoryService, outputChannel);
+      registerReplayCommands(context, simulationHistoryService, replayService, sidebarProvider);
+      outputChannel.appendLine(
+        '[Extension] Simulation replay service initialized and commands registered',
       );
     }
 

--- a/src/services/simulationReplayService.ts
+++ b/src/services/simulationReplayService.ts
@@ -1,0 +1,357 @@
+// ============================================================
+// src/services/simulationReplayService.ts
+// Handles replaying previous simulations with the same or
+// modified parameters. Integrates with SimulationHistoryService
+// for retrieving past entries and recording replay results.
+// ============================================================
+
+import {
+    SimulationHistoryService,
+    SimulationHistoryEntry,
+    SimulationOutcome,
+} from './simulationHistoryService';
+
+// ── Public types ──────────────────────────────────────────────
+
+/** Parameters that can be overridden when replaying a simulation. */
+export interface ReplayOverrides {
+    contractId?: string;
+    functionName?: string;
+    args?: unknown[];
+    network?: string;
+    source?: string;
+    method?: 'cli' | 'rpc';
+    label?: string;
+}
+
+/** Resolved parameters used to execute a replay. */
+export interface ReplayParameters {
+    contractId: string;
+    functionName: string;
+    args: unknown[];
+    network: string;
+    source: string;
+    method: 'cli' | 'rpc';
+    label?: string;
+}
+
+/** Result of a single simulation replay. */
+export interface ReplayResult {
+    /** The original history entry that was replayed. */
+    originalEntryId: string;
+    /** The newly recorded history entry from the replay. */
+    newEntryId: string;
+    /** Resolved parameters that were used for the replay. */
+    parameters: ReplayParameters;
+    /** Whether the replay simulation succeeded. */
+    outcome: SimulationOutcome;
+    /** Return value on success. */
+    result?: unknown;
+    /** Error message on failure. */
+    error?: string;
+    /** Duration of the replay in milliseconds. */
+    durationMs?: number;
+    /** Comparison with the original simulation. */
+    comparison: ReplayComparison;
+}
+
+/** Comparison between original and replayed simulation. */
+export interface ReplayComparison {
+    /** Whether the outcome changed between original and replay. */
+    outcomeChanged: boolean;
+    /** Whether the parameters were modified for the replay. */
+    parametersModified: boolean;
+    /** List of parameter fields that were overridden. */
+    modifiedFields: string[];
+    /** Original outcome for reference. */
+    originalOutcome: SimulationOutcome;
+    /** Replay outcome for reference. */
+    replayOutcome: SimulationOutcome;
+}
+
+/** Result of a batch replay operation. */
+export interface BatchReplayResult {
+    total: number;
+    succeeded: number;
+    failed: number;
+    skipped: number;
+    results: ReplayResult[];
+    errors: string[];
+}
+
+/** Callback invoked during simulation execution. */
+export type SimulationExecutor = (params: ReplayParameters) => Promise<{
+    success: boolean;
+    result?: unknown;
+    error?: string;
+    errorType?: string;
+    resourceUsage?: { cpuInstructions?: number; memoryBytes?: number };
+    durationMs?: number;
+}>;
+
+// ── Minimal VS Code-compatible interfaces ────────────────────
+
+interface SimpleOutputChannel {
+    appendLine(value: string): void;
+}
+
+// ── Service class ─────────────────────────────────────────────
+
+/**
+ * SimulationReplayService orchestrates replaying past simulations.
+ *
+ * Responsibilities:
+ * - Resolving replay parameters from a history entry + optional overrides
+ * - Delegating actual simulation execution to a caller-provided executor
+ * - Recording replay results back into simulation history
+ * - Comparing original vs. replay outcomes
+ * - Supporting batch replays across multiple history entries
+ */
+export class SimulationReplayService {
+    private readonly outputChannel: SimpleOutputChannel;
+
+    constructor(
+        private readonly historyService: SimulationHistoryService,
+        outputChannel?: SimpleOutputChannel
+    ) {
+        this.outputChannel = outputChannel ?? {
+            appendLine: (_msg: string) => { /* no-op */ },
+        };
+    }
+
+    // ── Public API ────────────────────────────────────────────
+
+    /**
+     * Replay a simulation from history.
+     *
+     * Resolves the original entry's parameters, applies any overrides,
+     * executes the simulation via the provided executor, records the
+     * result in history, and returns a comparison.
+     */
+    public async replaySimulation(
+        entryId: string,
+        executor: SimulationExecutor,
+        overrides: ReplayOverrides = {}
+    ): Promise<ReplayResult> {
+        const original = this.historyService.getEntry(entryId);
+        if (!original) {
+            throw new Error(`Simulation history entry not found: ${entryId}`);
+        }
+
+        const parameters = this.resolveParameters(original, overrides);
+        const comparison = this.buildPreComparison(original, parameters, overrides);
+
+        this.log(
+            `[Replay] Replaying ${parameters.functionName}() on ${parameters.contractId}` +
+            (comparison.parametersModified ? ` (modified: ${comparison.modifiedFields.join(', ')})` : '')
+        );
+
+        const startTime = Date.now();
+        let execResult: Awaited<ReturnType<SimulationExecutor>>;
+
+        try {
+            execResult = await executor(parameters);
+        } catch (err) {
+            const errorMsg = err instanceof Error ? err.message : String(err);
+            execResult = { success: false, error: `Replay execution failed: ${errorMsg}` };
+        }
+
+        const durationMs = execResult.durationMs ?? (Date.now() - startTime);
+
+        // Record the replay in history
+        const replayLabel = parameters.label
+            ? `Replay: ${parameters.label}`
+            : `Replay of ${entryId}`;
+
+        const newEntry = await this.historyService.recordSimulation({
+            contractId: parameters.contractId,
+            functionName: parameters.functionName,
+            args: parameters.args,
+            outcome: execResult.success ? 'success' : 'failure',
+            result: execResult.result,
+            error: execResult.error,
+            errorType: execResult.errorType,
+            resourceUsage: execResult.resourceUsage,
+            network: parameters.network,
+            source: parameters.source,
+            method: parameters.method,
+            durationMs,
+            label: replayLabel,
+        });
+
+        const replayOutcome: SimulationOutcome = execResult.success ? 'success' : 'failure';
+        comparison.replayOutcome = replayOutcome;
+        comparison.outcomeChanged = original.outcome !== replayOutcome;
+
+        const result: ReplayResult = {
+            originalEntryId: entryId,
+            newEntryId: newEntry.id,
+            parameters,
+            outcome: replayOutcome,
+            result: execResult.result,
+            error: execResult.error,
+            durationMs,
+            comparison,
+        };
+
+        this.log(
+            `[Replay] Completed: ${replayOutcome}` +
+            (comparison.outcomeChanged ? ` (outcome changed from ${original.outcome})` : '')
+        );
+
+        return result;
+    }
+
+    /**
+     * Replay multiple simulations from history in sequence.
+     *
+     * Entries that no longer exist in history are skipped.
+     * Execution continues even if individual replays fail.
+     */
+    public async batchReplay(
+        entryIds: string[],
+        executor: SimulationExecutor,
+        overrides: ReplayOverrides = {}
+    ): Promise<BatchReplayResult> {
+        const results: ReplayResult[] = [];
+        const errors: string[] = [];
+        let succeeded = 0;
+        let failed = 0;
+        let skipped = 0;
+
+        for (const entryId of entryIds) {
+            const original = this.historyService.getEntry(entryId);
+            if (!original) {
+                skipped++;
+                errors.push(`Skipped: entry ${entryId} not found in history`);
+                continue;
+            }
+
+            try {
+                const result = await this.replaySimulation(entryId, executor, overrides);
+                results.push(result);
+                if (result.outcome === 'success') {
+                    succeeded++;
+                } else {
+                    failed++;
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                errors.push(`Error replaying ${entryId}: ${msg}`);
+                failed++;
+            }
+        }
+
+        this.log(
+            `[Replay] Batch complete: ${succeeded} succeeded, ${failed} failed, ${skipped} skipped`
+        );
+
+        return {
+            total: entryIds.length,
+            succeeded,
+            failed,
+            skipped,
+            results,
+            errors,
+        };
+    }
+
+    /**
+     * Resolve the final parameters for a replay by merging the
+     * original entry's values with any caller-provided overrides.
+     */
+    public resolveParameters(
+        entry: SimulationHistoryEntry,
+        overrides: ReplayOverrides = {}
+    ): ReplayParameters {
+        return {
+            contractId: overrides.contractId ?? entry.contractId,
+            functionName: overrides.functionName ?? entry.functionName,
+            args: overrides.args ?? JSON.parse(JSON.stringify(entry.args)),
+            network: overrides.network ?? entry.network,
+            source: overrides.source ?? entry.source,
+            method: overrides.method ?? entry.method,
+            label: overrides.label,
+        };
+    }
+
+    /**
+     * Determine which fields differ between the original entry
+     * and the provided overrides.
+     */
+    public getModifiedFields(
+        entry: SimulationHistoryEntry,
+        overrides: ReplayOverrides
+    ): string[] {
+        const modified: string[] = [];
+
+        if (overrides.contractId !== undefined && overrides.contractId !== entry.contractId) {
+            modified.push('contractId');
+        }
+        if (overrides.functionName !== undefined && overrides.functionName !== entry.functionName) {
+            modified.push('functionName');
+        }
+        if (overrides.args !== undefined) {
+            const originalJson = JSON.stringify(entry.args);
+            const overrideJson = JSON.stringify(overrides.args);
+            if (originalJson !== overrideJson) {
+                modified.push('args');
+            }
+        }
+        if (overrides.network !== undefined && overrides.network !== entry.network) {
+            modified.push('network');
+        }
+        if (overrides.source !== undefined && overrides.source !== entry.source) {
+            modified.push('source');
+        }
+        if (overrides.method !== undefined && overrides.method !== entry.method) {
+            modified.push('method');
+        }
+
+        return modified;
+    }
+
+    /**
+     * Export a set of replay results as a JSON string for reporting.
+     */
+    public exportReplayResults(results: ReplayResult[]): string {
+        return JSON.stringify({
+            exportedAt: new Date().toISOString(),
+            totalReplays: results.length,
+            succeeded: results.filter(r => r.outcome === 'success').length,
+            failed: results.filter(r => r.outcome === 'failure').length,
+            outcomeChanges: results.filter(r => r.comparison.outcomeChanged).length,
+            results: results.map(r => ({
+                originalEntryId: r.originalEntryId,
+                newEntryId: r.newEntryId,
+                outcome: r.outcome,
+                durationMs: r.durationMs,
+                parametersModified: r.comparison.parametersModified,
+                modifiedFields: r.comparison.modifiedFields,
+                outcomeChanged: r.comparison.outcomeChanged,
+                originalOutcome: r.comparison.originalOutcome,
+            })),
+        }, null, 2);
+    }
+
+    // ── Private helpers ──────────────────────────────────────
+
+    private buildPreComparison(
+        original: SimulationHistoryEntry,
+        _parameters: ReplayParameters,
+        overrides: ReplayOverrides
+    ): ReplayComparison {
+        const modifiedFields = this.getModifiedFields(original, overrides);
+        return {
+            outcomeChanged: false, // will be updated after execution
+            parametersModified: modifiedFields.length > 0,
+            modifiedFields,
+            originalOutcome: original.outcome,
+            replayOutcome: original.outcome, // placeholder, updated after execution
+        };
+    }
+
+    private log(msg: string): void {
+        this.outputChannel.appendLine(msg);
+    }
+}

--- a/src/test/simulationReplay.test.ts
+++ b/src/test/simulationReplay.test.ts
@@ -1,0 +1,671 @@
+// ============================================================
+// src/test/simulationReplay.test.ts
+// Unit tests for SimulationReplayService.
+//
+// Run with:  node out-test/test/simulationReplay.test.js
+// ============================================================
+
+declare function require(name: string): any;
+declare const process: { exitCode?: number };
+
+const assert = require('assert');
+
+import {
+    SimulationHistoryService,
+    SimulationHistoryEntry,
+} from '../services/simulationHistoryService';
+
+import {
+    SimulationReplayService,
+    ReplayOverrides,
+    ReplayResult,
+    SimulationExecutor,
+} from '../services/simulationReplayService';
+
+// ── Mock helpers ──────────────────────────────────────────────
+
+function createMockContext() {
+    const store: Record<string, unknown> = {};
+    return {
+        workspaceState: {
+            get<T>(key: string, defaultValue: T): T {
+                return (store[key] as T) ?? defaultValue;
+            },
+            update(key: string, value: unknown): Promise<void> {
+                store[key] = value;
+                return Promise.resolve();
+            },
+        },
+        _store: store,
+    };
+}
+
+function createMockOutputChannel() {
+    const lines: string[] = [];
+    return {
+        appendLine(value: string) { lines.push(value); },
+        lines,
+    };
+}
+
+function createServices() {
+    const ctx = createMockContext();
+    const out = createMockOutputChannel();
+    const historyService = new SimulationHistoryService(ctx, out);
+    const replayService = new SimulationReplayService(historyService, out);
+    return { historyService, replayService, ctx, out };
+}
+
+function makeParams(overrides: Partial<Omit<SimulationHistoryEntry, 'id' | 'timestamp'>> = {}) {
+    return {
+        contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        functionName: 'hello',
+        args: [{ name: 'world' }],
+        outcome: 'success' as const,
+        result: 42,
+        network: 'testnet',
+        source: 'dev',
+        method: 'cli' as const,
+        durationMs: 150,
+        ...overrides,
+    };
+}
+
+function successExecutor(): SimulationExecutor {
+    return async (_params) => ({
+        success: true,
+        result: 'replay-result',
+        durationMs: 100,
+        resourceUsage: { cpuInstructions: 5000, memoryBytes: 2048 },
+    });
+}
+
+function failureExecutor(errorMsg: string = 'simulated failure'): SimulationExecutor {
+    return async (_params) => ({
+        success: false,
+        error: errorMsg,
+        errorType: 'CONTRACT_ERROR',
+        durationMs: 50,
+    });
+}
+
+function throwingExecutor(): SimulationExecutor {
+    return async (_params) => {
+        throw new Error('executor crashed');
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+async function testReplaySimulationSuccess() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor());
+
+    assert.strictEqual(result.originalEntryId, entry.id);
+    assert.ok(result.newEntryId, 'should have a new entry ID');
+    assert.notStrictEqual(result.newEntryId, entry.id, 'new entry should differ from original');
+    assert.strictEqual(result.outcome, 'success');
+    assert.strictEqual(result.result, 'replay-result');
+    assert.ok(result.durationMs !== undefined);
+    assert.strictEqual(result.comparison.outcomeChanged, false);
+    assert.strictEqual(result.comparison.parametersModified, false);
+    assert.strictEqual(result.comparison.modifiedFields.length, 0);
+    console.log('  [ok] replaySimulation succeeds with original parameters');
+}
+
+async function testReplaySimulationFailure() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ outcome: 'success' }));
+
+    const result = await replayService.replaySimulation(entry.id, failureExecutor());
+
+    assert.strictEqual(result.outcome, 'failure');
+    assert.strictEqual(result.error, 'simulated failure');
+    assert.strictEqual(result.comparison.outcomeChanged, true);
+    assert.strictEqual(result.comparison.originalOutcome, 'success');
+    assert.strictEqual(result.comparison.replayOutcome, 'failure');
+    console.log('  [ok] replaySimulation detects outcome change on failure');
+}
+
+async function testReplayRecordsInHistory() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+    assert.strictEqual(historyService.getEntryCount(), 1);
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor());
+
+    assert.strictEqual(historyService.getEntryCount(), 2);
+    const newEntry = historyService.getEntry(result.newEntryId);
+    assert.ok(newEntry, 'replay should be recorded in history');
+    assert.ok(newEntry!.label?.includes('Replay'), 'replay entry should have replay label');
+    console.log('  [ok] replay records new entry in simulation history');
+}
+
+async function testReplayNotFoundEntry() {
+    const { replayService } = createServices();
+    let threw = false;
+    try {
+        await replayService.replaySimulation('nonexistent', successExecutor());
+    } catch (e) {
+        threw = true;
+        assert.ok((e as Error).message.includes('not found'));
+    }
+    assert.ok(threw, 'should throw for nonexistent entry');
+    console.log('  [ok] replaySimulation throws for nonexistent entry');
+}
+
+async function testReplayWithOverrides() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const overrides: ReplayOverrides = {
+        network: 'mainnet',
+        source: 'prod',
+    };
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor(), overrides);
+
+    assert.strictEqual(result.parameters.network, 'mainnet');
+    assert.strictEqual(result.parameters.source, 'prod');
+    assert.strictEqual(result.parameters.contractId, entry.contractId, 'non-overridden fields preserved');
+    assert.strictEqual(result.comparison.parametersModified, true);
+    assert.ok(result.comparison.modifiedFields.includes('network'));
+    assert.ok(result.comparison.modifiedFields.includes('source'));
+    console.log('  [ok] replaySimulation applies overrides correctly');
+}
+
+async function testReplayWithArgsOverride() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ args: [{ name: 'original' }] }));
+
+    const overrides: ReplayOverrides = {
+        args: [{ name: 'modified' }],
+    };
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor(), overrides);
+
+    assert.deepStrictEqual(result.parameters.args, [{ name: 'modified' }]);
+    assert.ok(result.comparison.modifiedFields.includes('args'));
+    console.log('  [ok] replaySimulation applies args override');
+}
+
+async function testReplayWithSameArgsNotModified() {
+    const { historyService, replayService } = createServices();
+    const originalArgs = [{ name: 'world' }];
+    const entry = await historyService.recordSimulation(makeParams({ args: originalArgs }));
+
+    const overrides: ReplayOverrides = {
+        args: [{ name: 'world' }],
+    };
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor(), overrides);
+
+    assert.strictEqual(result.comparison.parametersModified, false);
+    assert.strictEqual(result.comparison.modifiedFields.length, 0);
+    console.log('  [ok] identical args override not counted as modification');
+}
+
+async function testReplayWithExecutorException() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const result = await replayService.replaySimulation(entry.id, throwingExecutor());
+
+    assert.strictEqual(result.outcome, 'failure');
+    assert.ok(result.error?.includes('executor crashed'));
+    assert.strictEqual(historyService.getEntryCount(), 2, 'failure should still be recorded');
+    console.log('  [ok] replaySimulation handles executor exceptions gracefully');
+}
+
+async function testReplayWithCustomLabel() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const overrides: ReplayOverrides = { label: 'my-test-run' };
+    const result = await replayService.replaySimulation(entry.id, successExecutor(), overrides);
+
+    const newEntry = historyService.getEntry(result.newEntryId);
+    assert.ok(newEntry!.label?.includes('my-test-run'));
+    console.log('  [ok] replay uses custom label in history entry');
+}
+
+async function testResolveParameters() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const params = replayService.resolveParameters(entry, { network: 'futurenet' });
+
+    assert.strictEqual(params.contractId, entry.contractId);
+    assert.strictEqual(params.functionName, entry.functionName);
+    assert.strictEqual(params.network, 'futurenet');
+    assert.strictEqual(params.source, entry.source);
+    assert.strictEqual(params.method, entry.method);
+    console.log('  [ok] resolveParameters merges entry with overrides');
+}
+
+async function testResolveParametersNoOverrides() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const params = replayService.resolveParameters(entry);
+
+    assert.strictEqual(params.contractId, entry.contractId);
+    assert.strictEqual(params.functionName, entry.functionName);
+    assert.strictEqual(params.network, entry.network);
+    assert.deepStrictEqual(params.args, entry.args);
+    console.log('  [ok] resolveParameters returns original values with no overrides');
+}
+
+async function testResolveParametersDeepCopiesArgs() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ args: [{ nested: 'value' }] }));
+
+    const params = replayService.resolveParameters(entry);
+
+    // Mutating resolved args should not affect the original entry
+    (params.args[0] as any).nested = 'mutated';
+    const refetched = historyService.getEntry(entry.id);
+    assert.strictEqual((refetched!.args[0] as any).nested, 'value', 'original should be unchanged');
+    console.log('  [ok] resolveParameters deep-copies args array');
+}
+
+async function testGetModifiedFields() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const fields = replayService.getModifiedFields(entry, {
+        contractId: 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+        functionName: 'transfer',
+        network: 'mainnet',
+    });
+
+    assert.ok(fields.includes('contractId'));
+    assert.ok(fields.includes('functionName'));
+    assert.ok(fields.includes('network'));
+    assert.strictEqual(fields.length, 3);
+    console.log('  [ok] getModifiedFields detects changed fields');
+}
+
+async function testGetModifiedFieldsNoChanges() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const fields = replayService.getModifiedFields(entry, {});
+
+    assert.strictEqual(fields.length, 0);
+    console.log('  [ok] getModifiedFields returns empty for no overrides');
+}
+
+async function testGetModifiedFieldsSameValues() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const fields = replayService.getModifiedFields(entry, {
+        contractId: entry.contractId,
+        network: entry.network,
+    });
+
+    assert.strictEqual(fields.length, 0, 'same values should not count as modified');
+    console.log('  [ok] getModifiedFields ignores overrides with same values');
+}
+
+async function testGetModifiedFieldsMethodChange() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ method: 'cli' }));
+
+    const fields = replayService.getModifiedFields(entry, { method: 'rpc' });
+
+    assert.ok(fields.includes('method'));
+    console.log('  [ok] getModifiedFields detects method change');
+}
+
+async function testBatchReplaySuccess() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams({ functionName: 'fn1' }));
+    const e2 = await historyService.recordSimulation(makeParams({ functionName: 'fn2' }));
+    const e3 = await historyService.recordSimulation(makeParams({ functionName: 'fn3' }));
+
+    const result = await replayService.batchReplay(
+        [e1.id, e2.id, e3.id],
+        successExecutor()
+    );
+
+    assert.strictEqual(result.total, 3);
+    assert.strictEqual(result.succeeded, 3);
+    assert.strictEqual(result.failed, 0);
+    assert.strictEqual(result.skipped, 0);
+    assert.strictEqual(result.results.length, 3);
+    assert.strictEqual(result.errors.length, 0);
+    // Original 3 + 3 replays
+    assert.strictEqual(historyService.getEntryCount(), 6);
+    console.log('  [ok] batchReplay succeeds for all entries');
+}
+
+async function testBatchReplayWithMixedResults() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams({ functionName: 'fn1' }));
+    const e2 = await historyService.recordSimulation(makeParams({ functionName: 'fn2' }));
+
+    let callCount = 0;
+    const mixedExecutor: SimulationExecutor = async (_params) => {
+        callCount++;
+        if (callCount === 1) {
+            return { success: true, result: 'ok', durationMs: 50 };
+        }
+        return { success: false, error: 'second failed', durationMs: 30 };
+    };
+
+    const result = await replayService.batchReplay([e1.id, e2.id], mixedExecutor);
+
+    assert.strictEqual(result.total, 2);
+    assert.strictEqual(result.succeeded, 1);
+    assert.strictEqual(result.failed, 1);
+    assert.strictEqual(result.results.length, 2);
+    console.log('  [ok] batchReplay handles mixed success/failure');
+}
+
+async function testBatchReplaySkipsMissing() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams());
+
+    const result = await replayService.batchReplay(
+        [e1.id, 'nonexistent_1', 'nonexistent_2'],
+        successExecutor()
+    );
+
+    assert.strictEqual(result.total, 3);
+    assert.strictEqual(result.succeeded, 1);
+    assert.strictEqual(result.skipped, 2);
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(result.errors.length, 2);
+    assert.ok(result.errors[0].includes('not found'));
+    console.log('  [ok] batchReplay skips missing entries');
+}
+
+async function testBatchReplayWithOverrides() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams({ network: 'testnet' }));
+    const e2 = await historyService.recordSimulation(makeParams({ network: 'testnet' }));
+
+    const result = await replayService.batchReplay(
+        [e1.id, e2.id],
+        successExecutor(),
+        { network: 'mainnet' }
+    );
+
+    assert.strictEqual(result.succeeded, 2);
+    for (const r of result.results) {
+        assert.strictEqual(r.parameters.network, 'mainnet');
+        assert.ok(r.comparison.parametersModified);
+        assert.ok(r.comparison.modifiedFields.includes('network'));
+    }
+    console.log('  [ok] batchReplay applies overrides to all entries');
+}
+
+async function testBatchReplayEmptyList() {
+    const { replayService } = createServices();
+
+    const result = await replayService.batchReplay([], successExecutor());
+
+    assert.strictEqual(result.total, 0);
+    assert.strictEqual(result.succeeded, 0);
+    assert.strictEqual(result.failed, 0);
+    assert.strictEqual(result.skipped, 0);
+    assert.strictEqual(result.results.length, 0);
+    console.log('  [ok] batchReplay handles empty entry list');
+}
+
+async function testBatchReplayWithThrowingExecutor() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams());
+
+    const result = await replayService.batchReplay([e1.id], throwingExecutor());
+
+    // Throwing executor is caught inside replaySimulation, so it records a failure
+    assert.strictEqual(result.total, 1);
+    assert.strictEqual(result.failed, 1);
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(result.results[0].outcome, 'failure');
+    console.log('  [ok] batchReplay handles throwing executor');
+}
+
+async function testExportReplayResults() {
+    const { historyService, replayService } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams());
+    const e2 = await historyService.recordSimulation(makeParams({ outcome: 'failure', error: 'err' }));
+
+    const r1 = await replayService.replaySimulation(e1.id, successExecutor());
+    const r2 = await replayService.replaySimulation(e2.id, failureExecutor());
+
+    const json = replayService.exportReplayResults([r1, r2]);
+    const parsed = JSON.parse(json);
+
+    assert.ok(parsed.exportedAt);
+    assert.strictEqual(parsed.totalReplays, 2);
+    assert.strictEqual(parsed.succeeded, 1);
+    assert.strictEqual(parsed.failed, 1);
+    assert.ok(Array.isArray(parsed.results));
+    assert.strictEqual(parsed.results.length, 2);
+    assert.ok(parsed.results[0].originalEntryId);
+    assert.ok(parsed.results[0].newEntryId);
+    console.log('  [ok] exportReplayResults produces valid JSON');
+}
+
+async function testExportReplayResultsEmpty() {
+    const { replayService } = createServices();
+
+    const json = replayService.exportReplayResults([]);
+    const parsed = JSON.parse(json);
+
+    assert.strictEqual(parsed.totalReplays, 0);
+    assert.strictEqual(parsed.succeeded, 0);
+    assert.strictEqual(parsed.failed, 0);
+    assert.strictEqual(parsed.results.length, 0);
+    console.log('  [ok] exportReplayResults handles empty results');
+}
+
+async function testExportReplayResultsOutcomeChanges() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ outcome: 'success' }));
+
+    const result = await replayService.replaySimulation(entry.id, failureExecutor());
+
+    const json = replayService.exportReplayResults([result]);
+    const parsed = JSON.parse(json);
+
+    assert.strictEqual(parsed.outcomeChanges, 1);
+    assert.strictEqual(parsed.results[0].outcomeChanged, true);
+    assert.strictEqual(parsed.results[0].originalOutcome, 'success');
+    console.log('  [ok] exportReplayResults tracks outcome changes');
+}
+
+async function testReplayOutcomeUnchangedWhenBothSucceed() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({ outcome: 'success' }));
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor());
+
+    assert.strictEqual(result.comparison.outcomeChanged, false);
+    assert.strictEqual(result.comparison.originalOutcome, 'success');
+    assert.strictEqual(result.comparison.replayOutcome, 'success');
+    console.log('  [ok] outcome unchanged when both succeed');
+}
+
+async function testReplayOutcomeUnchangedWhenBothFail() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({
+        outcome: 'failure',
+        error: 'original error',
+    }));
+
+    const result = await replayService.replaySimulation(entry.id, failureExecutor('new error'));
+
+    assert.strictEqual(result.comparison.outcomeChanged, false);
+    assert.strictEqual(result.comparison.originalOutcome, 'failure');
+    assert.strictEqual(result.comparison.replayOutcome, 'failure');
+    console.log('  [ok] outcome unchanged when both fail');
+}
+
+async function testReplayOutcomeChangedFailToSuccess() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({
+        outcome: 'failure',
+        error: 'was broken',
+    }));
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor());
+
+    assert.strictEqual(result.comparison.outcomeChanged, true);
+    assert.strictEqual(result.comparison.originalOutcome, 'failure');
+    assert.strictEqual(result.comparison.replayOutcome, 'success');
+    console.log('  [ok] outcome change detected: failure → success');
+}
+
+async function testOutputChannelLogging() {
+    const { historyService, replayService, out } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    await replayService.replaySimulation(entry.id, successExecutor());
+
+    assert.ok(out.lines.some(l => l.includes('[Replay]')), 'should log replay messages');
+    assert.ok(out.lines.some(l => l.includes('Replaying')));
+    assert.ok(out.lines.some(l => l.includes('Completed')));
+    console.log('  [ok] service logs replay activity to output channel');
+}
+
+async function testBatchReplayLogging() {
+    const { historyService, replayService, out } = createServices();
+    const e1 = await historyService.recordSimulation(makeParams());
+
+    await replayService.batchReplay([e1.id], successExecutor());
+
+    assert.ok(out.lines.some(l => l.includes('Batch complete')));
+    console.log('  [ok] batch replay logs completion summary');
+}
+
+async function testReplayPreservesOriginalEntry() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams({
+        functionName: 'original_fn',
+        args: [{ key: 'original_val' }],
+    }));
+
+    await replayService.replaySimulation(entry.id, successExecutor(), {
+        functionName: 'modified_fn',
+        args: [{ key: 'modified_val' }],
+    });
+
+    const original = historyService.getEntry(entry.id);
+    assert.ok(original, 'original entry should still exist');
+    assert.strictEqual(original!.functionName, 'original_fn');
+    assert.deepStrictEqual(original!.args, [{ key: 'original_val' }]);
+    console.log('  [ok] replay does not mutate original history entry');
+}
+
+async function testReplayDurationFromExecutor() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const executor: SimulationExecutor = async () => ({
+        success: true,
+        result: 'ok',
+        durationMs: 999,
+    });
+
+    const result = await replayService.replaySimulation(entry.id, executor);
+
+    assert.strictEqual(result.durationMs, 999);
+    console.log('  [ok] replay uses duration from executor when provided');
+}
+
+async function testReplayAllFieldOverrides() {
+    const { historyService, replayService } = createServices();
+    const entry = await historyService.recordSimulation(makeParams());
+
+    const overrides: ReplayOverrides = {
+        contractId: 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+        functionName: 'transfer',
+        args: [{ to: 'alice', amount: 100 }],
+        network: 'mainnet',
+        source: 'prod',
+        method: 'rpc',
+    };
+
+    const result = await replayService.replaySimulation(entry.id, successExecutor(), overrides);
+
+    assert.strictEqual(result.parameters.contractId, overrides.contractId);
+    assert.strictEqual(result.parameters.functionName, overrides.functionName);
+    assert.deepStrictEqual(result.parameters.args, overrides.args);
+    assert.strictEqual(result.parameters.network, overrides.network);
+    assert.strictEqual(result.parameters.source, overrides.source);
+    assert.strictEqual(result.parameters.method, overrides.method);
+    assert.strictEqual(result.comparison.modifiedFields.length, 6);
+    console.log('  [ok] all parameter fields can be overridden');
+}
+
+// ── Runner ────────────────────────────────────────────────────
+
+async function run() {
+    const tests = [
+        testReplaySimulationSuccess,
+        testReplaySimulationFailure,
+        testReplayRecordsInHistory,
+        testReplayNotFoundEntry,
+        testReplayWithOverrides,
+        testReplayWithArgsOverride,
+        testReplayWithSameArgsNotModified,
+        testReplayWithExecutorException,
+        testReplayWithCustomLabel,
+        testResolveParameters,
+        testResolveParametersNoOverrides,
+        testResolveParametersDeepCopiesArgs,
+        testGetModifiedFields,
+        testGetModifiedFieldsNoChanges,
+        testGetModifiedFieldsSameValues,
+        testGetModifiedFieldsMethodChange,
+        testBatchReplaySuccess,
+        testBatchReplayWithMixedResults,
+        testBatchReplaySkipsMissing,
+        testBatchReplayWithOverrides,
+        testBatchReplayEmptyList,
+        testBatchReplayWithThrowingExecutor,
+        testExportReplayResults,
+        testExportReplayResultsEmpty,
+        testExportReplayResultsOutcomeChanges,
+        testReplayOutcomeUnchangedWhenBothSucceed,
+        testReplayOutcomeUnchangedWhenBothFail,
+        testReplayOutcomeChangedFailToSuccess,
+        testOutputChannelLogging,
+        testBatchReplayLogging,
+        testReplayPreservesOriginalEntry,
+        testReplayDurationFromExecutor,
+        testReplayAllFieldOverrides,
+    ];
+
+    let passed = 0;
+    let failed = 0;
+
+    console.log('\nsimulationReplay unit tests');
+    for (const test of tests) {
+        try {
+            await test();
+            passed += 1;
+        } catch (err) {
+            failed += 1;
+            console.error(`  [fail] ${test.name}`);
+            console.error(`         ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);
+    if (failed > 0) {
+        process.exitCode = 1;
+    }
+}
+
+run().catch(err => {
+    console.error('Test runner error:', err);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## feat: simulation replay functionality

Closes #19

### Summary

Implements simulation replay functionality, allowing developers to replay previous simulations with the same or modified parameters. This feature stores simulation history and enables quick replay of past simulations, helping developers test different scenarios and compare results.

### What's New

#### Simulation Replay Service

A new service that orchestrates replaying past simulations:

- **Single replay** — Replay any simulation from history with original parameters
- **Replay with modifications** — Override any combination of contract ID, function name, arguments, network, source, or method before replaying
- **Batch replay** — Replay multiple simulations in sequence with optional shared overrides
- **Outcome comparison** — Automatically compares original vs. replay outcomes and reports changes
- **Deep parameter isolation** — Resolved replay parameters are deep-copied to prevent mutation of original history entries
- **Export replay results** — Export replay results as structured JSON for reporting and analysis

#### New Commands

| Command | Description |
|---------|-------------|
| `Stellar Suite: Replay Simulation` | Pick a simulation from history and replay it |
| `Stellar Suite: Replay Simulation with Modifications` | Pick a simulation, modify parameters, then replay |
| `Stellar Suite: Batch Replay Simulations` | Multi-select simulations from history and replay all |
| `Stellar Suite: Export Replay Results` | Export the last replay results to a JSON file |

#### Integration

- Replay results are automatically recorded back into simulation history with a `Replay` label
- Results are displayed in the existing Simulation Panel
- Sidebar is updated after replays complete
- Batch replay shows a progress notification with a summary of successes, failures, skips, and outcome changes
- Full integration with existing CLI and RPC execution paths

### Acceptance Criteria

- [x] Store simulation history
- [x] Replay previous simulations
- [x] Modify parameters during replay
- [x] Display simulation history
- [x] Support replay from history
- [x] Handle replay errors
- [x] Export simulation history
- [x] Clear simulation history

### Testing

33 unit tests covering:

- Single replay (success, failure, outcome changes)
- Parameter override resolution and deep-copy safety
- Modified field detection (all fields, no changes, same-value overrides)
- Batch replay (success, mixed results, missing entries, empty list, throwing executor)
- Export of replay results (valid JSON, empty, outcome change tracking)
- Executor exception handling (graceful degradation, still records in history)
- Output channel logging for replay and batch operations
- Original history entry immutability after replay

All 33 tests pass. Existing tests unaffected.

### Deliverables

- [x] Simulation replay service
- [x] Replay functionality
- [x] History storage (via existing SimulationHistoryService)
- [x] Replay parameter modification
- [x] History export
- [x] Integration with simulation service
- [x] Unit tests for replay