### PR TITLE
Implement form input sanitization

### DIFF
--- a/docs/input-sanitization.md
+++ b/docs/input-sanitization.md
@@ -1,0 +1,242 @@
+# Input Sanitization
+
+Stellar Suite sanitizes all user-supplied inputs before they are passed to CLI
+commands, stored in workspace state, or displayed in the UI.  This prevents
+malicious input, data corruption, and injection attacks.
+
+---
+
+## Service
+
+**`src/services/inputSanitizationService.ts`** — `InputSanitizationService`
+
+### Construction
+
+```ts
+import { InputSanitizationService } from './services/inputSanitizationService';
+
+// Uses the built-in console logger
+const sanitizer = new InputSanitizationService();
+
+// Or supply a custom logger (e.g., one that writes to an OutputChannel)
+const sanitizer = new InputSanitizationService(myLogger);
+```
+
+### Return type — `SanitizationResult<T>`
+
+Every method returns a `SanitizationResult`:
+
+| Field | Type | Description |
+|---|---|---|
+| `valid` | `boolean` | `true` if the value is safe to use |
+| `sanitizedValue` | `T` | The cleaned value |
+| `errors` | `string[]` | Hard errors that prevent use |
+| `warnings` | `string[]` | Non-blocking warnings |
+| `logs` | `SanitizationLogEntry[]` | Detailed log of every action taken |
+| `wasModified` | `boolean` | `true` if the original value was changed |
+
+---
+
+## Methods
+
+### `sanitizeString(value, options?)`
+
+General-purpose string sanitization.  Applied steps (in order):
+
+1. Null / undefined → empty string
+2. Trim leading/trailing whitespace *(default: on)*
+3. Strip null bytes `\0` *(default: on)*
+4. Strip dangerous control characters *(default: on)*
+5. Normalize Unicode to NFC form *(default: on)*
+6. Enforce `minLength` / `maxLength` constraints
+7. Apply custom rules
+
+**Options** (`SanitizeStringOptions`):
+
+| Option | Default | Description |
+|---|---|---|
+| `field` | `'input'` | Field name used in log messages |
+| `maxLength` | `4096` | Maximum allowed length |
+| `minLength` | `0` | Minimum required length |
+| `trim` | `true` | Trim whitespace |
+| `stripNullBytes` | `true` | Remove `\0` characters |
+| `stripControlChars` | `true` | Remove ASCII control characters |
+| `normalizeUnicode` | `true` | Normalize to NFC |
+| `allowNewlines` | `false` | Preserve `\n` characters |
+| `customRules` | `[]` | Additional `SanitizationRule` objects |
+
+---
+
+### `sanitizeContractId(value, options?)`
+
+Validates a Stellar contract ID (strkey format).
+
+- Trims and uppercases the input
+- Rejects values that do not match `/^C[A-Z0-9]{55}$/`
+
+```ts
+const result = sanitizer.sanitizeContractId(rawInput, { field: 'contractId' });
+if (!result.valid) {
+    vscode.window.showErrorMessage(result.errors[0]);
+    return;
+}
+const contractId = result.sanitizedValue; // safe to use
+```
+
+---
+
+### `sanitizeNetworkName(value, options?)`
+
+Validates a Stellar network name.
+
+- Trims and lowercases the input
+- Rejects values not in the allowed list
+
+Default allowed networks: `testnet`, `mainnet`, `futurenet`, `local`, `standalone`
+
+```ts
+const result = sanitizer.sanitizeNetworkName(rawNetwork, {
+    allowedNetworks: ['testnet', 'mainnet'],
+});
+```
+
+---
+
+### `sanitizePath(value, options?)`
+
+Validates a file system path.
+
+- Rejects path traversal sequences (`..`) by default
+- Warns on absolute paths when `allowAbsolute: false`
+
+```ts
+const result = sanitizer.sanitizePath(rawPath, { allowAbsolute: false });
+```
+
+---
+
+### `sanitizeJson(value, options?)`
+
+Validates and canonicalizes a JSON string.
+
+- Parses the JSON (rejects invalid JSON)
+- Enforces `maxDepth` (default: 10) and `maxKeys` (default: 100)
+- Re-serializes to canonical form (removes extra whitespace)
+
+```ts
+const result = sanitizer.sanitizeJson(rawArgs, { maxDepth: 5 });
+if (result.valid) {
+    const args = JSON.parse(result.sanitizedValue);
+}
+```
+
+---
+
+### `sanitizeFunctionName(value, options?)`
+
+Validates a Soroban contract function name.
+
+- Must match `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
+
+---
+
+### `sanitizeEnvVarName(value, options?)`
+
+Validates an environment variable name.
+
+- Normalizes to uppercase
+- Must match `/^[A-Z_][A-Z0-9_]*$/`
+
+---
+
+### `sanitizeEnvVarValue(value, options?)`
+
+Sanitizes an environment variable value.
+
+- Strips null bytes
+- Warns (non-blocking) if the value contains shell metacharacters
+
+---
+
+### `sanitizeFormFields(fields, perFieldOptions?)`
+
+Batch-sanitizes a record of form fields.
+
+```ts
+const results = sanitizer.sanitizeFormFields(
+    { contractId: rawId, network: rawNetwork },
+    { contractId: { maxLength: 56 } },
+);
+
+if (!InputSanitizationService.allValid(results)) {
+    const errors = InputSanitizationService.collectErrors(results);
+    vscode.window.showErrorMessage(errors.join('\n'));
+    return;
+}
+```
+
+---
+
+## Custom Sanitization Rules
+
+Implement the `SanitizationRule` interface to add project-specific rules:
+
+```ts
+import { SanitizationRule } from './services/inputSanitizationService';
+
+const noSqlInjectionRule: SanitizationRule = {
+    id: 'no-sql-injection',
+    description: 'Reject SQL injection patterns',
+    apply(value: string, field: string): string {
+        if (/('|--|;|\/\*|\*\/)/.test(value)) {
+            throw new Error('Input contains SQL injection patterns');
+        }
+        return value;
+    },
+};
+
+const result = sanitizer.sanitizeString(rawInput, {
+    customRules: [noSqlInjectionRule],
+});
+```
+
+---
+
+## Integration Points
+
+The sanitization service is integrated into the following commands:
+
+| Command | Fields sanitized |
+|---|---|
+| `simulateTransaction` | Contract ID, function name, JSON arguments |
+| `registerEnvVariableCommands` | Env var name, env var value |
+
+---
+
+## Logging
+
+Every sanitization action is logged.  By default, logs go to the console.
+Supply a custom `SanitizationLogger` to redirect logs to a VS Code
+`OutputChannel`:
+
+```ts
+import { SanitizationLogger } from './services/inputSanitizationService';
+
+class OutputChannelLogger implements SanitizationLogger {
+    constructor(private readonly channel: vscode.OutputChannel) {}
+    info(msg: string) { this.channel.appendLine(`[INFO] ${msg}`); }
+    warn(msg: string) { this.channel.appendLine(`[WARN] ${msg}`); }
+    error(msg: string) { this.channel.appendLine(`[ERROR] ${msg}`); }
+}
+
+const sanitizer = new InputSanitizationService(
+    new OutputChannelLogger(outputChannel),
+);
+```
+
+---
+
+## Tests
+
+Unit tests are located at `src/test/inputSanitizationService.test.ts` and
+cover all public methods with both valid and invalid inputs.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,7 +193,7 @@ const copyContractIdCommand = vscode.commands.registerCommand(
 
     const exportHistoryCommand = vscode.commands.registerCommand(
       "stellarSuite.exportSimulationHistory",
-      () => exportSimulationHistory(context, simulationHistoryService!),
+      () => exportSimulationHistory(context),
     );
 
     const showVersionMismatchesCommand = vscode.commands.registerCommand(
@@ -289,35 +289,22 @@ const copyContractIdCommand = vscode.commands.registerCommand(
       },
     );
 
-const simulateFromSidebarCommand = vscode.commands.registerCommand(
-  "stellarSuite.simulateFromSidebar",
-  (contractId: string) =>
-    simulateTransaction(
-      context,
-      sidebarProvider,
-    ),
-);
+    const refreshCommand = vscode.commands.registerCommand(
+      "stellarSuite.refresh",
+      async () => {
+        sidebarProvider?.refresh();
+      },
+    );
 
-const refreshCommand = vscode.commands.registerCommand(
-  "stellarSuite.refresh",
-  async () => {
-    sidebarProvider?.refresh();
-  },
-);
-
-// 10. File Watchers
+    // 11. File Watchers (simulateFromSidebar)
     const simulateFromSidebarCommand = vscode.commands.registerCommand(
       "stellarSuite.simulateFromSidebar",
-      (contractId: string) =>
-        simulateTransaction(
-          context,
-          sidebarProvider,
-          simulationHistoryService,
-          cliHistoryService,
-          fallbackService,
-          resourceProfilingService,
-          contractId,
-        ),
+      (contractId: string) => {
+        if (typeof contractId === "string") {
+          context.workspaceState.update("selectedContractPath", contractId);
+        }
+        return simulateTransaction(context, sidebarProvider);
+      },
     );
 
     // 11. File Watchers
@@ -371,12 +358,6 @@ const refreshCommand = vscode.commands.registerCommand(
       }
       console.error("[Stellar Suite] Activation error:", error);
     }
-  }
-    console.error("[Stellar Suite] Activation error:", error);
-    vscode.window.showErrorMessage(
-      `Stellar Suite activation failed: ${errorMsg}`,
-    );
-  }
 }
 
 export function deactivate() {

--- a/src/services/inputSanitizationService.ts
+++ b/src/services/inputSanitizationService.ts
@@ -1,0 +1,809 @@
+// ============================================================
+// src/services/inputSanitizationService.ts
+// Input sanitization service for Stellar Suite.
+// Sanitizes user inputs before processing and submission to
+// prevent malicious input and ensure data safety.
+// ============================================================
+
+// ── Types ─────────────────────────────────────────────────────
+
+/** Severity level for sanitization log entries */
+export type SanitizationLogLevel = 'info' | 'warn' | 'error';
+
+/** A single sanitization log entry */
+export interface SanitizationLogEntry {
+    level: SanitizationLogLevel;
+    field: string;
+    message: string;
+    originalValue?: string;
+    sanitizedValue?: string;
+    timestamp: string;
+}
+
+/** Result of a sanitization operation */
+export interface SanitizationResult<T = string> {
+    /** Whether the sanitized value is safe to use */
+    valid: boolean;
+    /** The sanitized (cleaned) value */
+    sanitizedValue: T;
+    /** Human-readable errors that prevent use of the value */
+    errors: string[];
+    /** Non-blocking warnings about the input */
+    warnings: string[];
+    /** Log entries produced during sanitization */
+    logs: SanitizationLogEntry[];
+    /** Whether the original value was modified during sanitization */
+    wasModified: boolean;
+}
+
+/** A custom sanitization rule */
+export interface SanitizationRule {
+    /** Unique identifier for the rule */
+    id: string;
+    /** Human-readable description */
+    description: string;
+    /**
+     * Apply the rule to a value.
+     * Return the (possibly modified) value, or throw to signal an error.
+     */
+    apply(value: string, field: string): string;
+}
+
+/** Options for sanitizing a string field */
+export interface SanitizeStringOptions {
+    /** Field name used in log messages */
+    field?: string;
+    /** Maximum allowed length (default: 4096) */
+    maxLength?: number;
+    /** Minimum required length (default: 0) */
+    minLength?: number;
+    /** Whether to trim leading/trailing whitespace (default: true) */
+    trim?: boolean;
+    /** Whether to strip null bytes (default: true) */
+    stripNullBytes?: boolean;
+    /** Whether to strip control characters except newline/tab (default: true) */
+    stripControlChars?: boolean;
+    /** Whether to normalize Unicode to NFC form (default: true) */
+    normalizeUnicode?: boolean;
+    /** Whether to allow newlines in the value (default: false) */
+    allowNewlines?: boolean;
+    /** Additional custom rules to apply */
+    customRules?: SanitizationRule[];
+}
+
+/** Options for sanitizing a contract ID */
+export interface SanitizeContractIdOptions {
+    field?: string;
+}
+
+/** Options for sanitizing a network name */
+export interface SanitizeNetworkOptions {
+    field?: string;
+    /** Allowed network names (default: ['testnet', 'mainnet', 'futurenet', 'local', 'standalone']) */
+    allowedNetworks?: string[];
+}
+
+/** Options for sanitizing a file path */
+export interface SanitizePathOptions {
+    field?: string;
+    /** Whether to allow absolute paths (default: true) */
+    allowAbsolute?: boolean;
+    /** Whether to allow path traversal sequences (default: false) */
+    allowTraversal?: boolean;
+}
+
+/** Options for sanitizing a JSON string */
+export interface SanitizeJsonOptions {
+    field?: string;
+    /** Maximum depth of the parsed JSON object (default: 10) */
+    maxDepth?: number;
+    /** Maximum number of keys in any object (default: 100) */
+    maxKeys?: number;
+}
+
+// ── Logger ────────────────────────────────────────────────────
+
+export interface SanitizationLogger {
+    info(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+}
+
+export class ConsoleSanitizationLogger implements SanitizationLogger {
+    private readonly prefix: string;
+    constructor(prefix = '[InputSanitization]') {
+        this.prefix = prefix;
+    }
+    info(message: string): void { console.log(`${this.prefix} ${message}`); }
+    warn(message: string): void { console.warn(`${this.prefix} ${message}`); }
+    error(message: string): void { console.error(`${this.prefix} ${message}`); }
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+/** Measure the depth of a parsed JSON value */
+function jsonDepth(value: unknown, current = 0): number {
+    if (current > 20) { return current; } // guard against infinite recursion
+    if (Array.isArray(value)) {
+        if (value.length === 0) { return current + 1; }
+        return Math.max(...value.map(v => jsonDepth(v, current + 1)));
+    }
+    if (value !== null && typeof value === 'object') {
+        const vals = Object.values(value as Record<string, unknown>);
+        if (vals.length === 0) { return current + 1; }
+        return Math.max(...vals.map(v => jsonDepth(v, current + 1)));
+    }
+    return current;
+}
+
+/** Count the maximum number of keys in any object within a JSON value */
+function maxObjectKeys(value: unknown): number {
+    if (Array.isArray(value)) {
+        return value.reduce<number>((acc, v) => Math.max(acc, maxObjectKeys(v)), 0);
+    }
+    if (value !== null && typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        const ownKeys = Object.keys(obj).length;
+        const childMax = Object.values(obj).reduce<number>((acc, v) => Math.max(acc, maxObjectKeys(v)), 0);
+        return Math.max(ownKeys, childMax);
+    }
+    return 0;
+}
+
+// ── Service ───────────────────────────────────────────────────
+
+/**
+ * InputSanitizationService
+ *
+ * Provides methods to sanitize and validate user-supplied inputs before
+ * they are passed to CLI commands, stored in workspace state, or displayed
+ * in the UI.  All methods are pure (no side-effects beyond logging) and
+ * return a {@link SanitizationResult} that callers can inspect.
+ */
+export class InputSanitizationService {
+    private readonly logger: SanitizationLogger;
+
+    /** Default allowed network names */
+    static readonly DEFAULT_ALLOWED_NETWORKS = [
+        'testnet',
+        'mainnet',
+        'futurenet',
+        'local',
+        'standalone',
+    ];
+
+    constructor(logger?: SanitizationLogger) {
+        this.logger = logger ?? new ConsoleSanitizationLogger();
+    }
+
+    // ── String sanitization ──────────────────────────────────
+
+    /**
+     * Sanitize a generic string input.
+     *
+     * Applies the following steps in order:
+     * 1. Null / undefined guard → empty string
+     * 2. Trim whitespace (optional)
+     * 3. Strip null bytes
+     * 4. Strip dangerous control characters
+     * 5. Normalize Unicode (NFC)
+     * 6. Enforce length constraints
+     * 7. Apply custom rules
+     */
+    sanitizeString(
+        value: unknown,
+        options: SanitizeStringOptions = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'input';
+        const logs: SanitizationLogEntry[] = [];
+        const errors: string[] = [];
+        const warnings: string[] = [];
+
+        const addLog = (
+            level: SanitizationLogLevel,
+            message: string,
+            original?: string,
+            sanitized?: string,
+        ): void => {
+            const entry: SanitizationLogEntry = {
+                level,
+                field,
+                message,
+                originalValue: original,
+                sanitizedValue: sanitized,
+                timestamp: new Date().toISOString(),
+            };
+            logs.push(entry);
+            this.logger[level](`[${field}] ${message}`);
+        };
+
+        // 1. Null / undefined guard
+        if (value === null || value === undefined) {
+            addLog('warn', 'Received null/undefined value; treating as empty string');
+            return { valid: true, sanitizedValue: '', errors, warnings, logs, wasModified: true };
+        }
+
+        // Coerce to string
+        let str = String(value);
+        const original = str;
+
+        // 2. Trim
+        const trim = options.trim !== false;
+        if (trim) {
+            const trimmed = str.trim();
+            if (trimmed !== str) {
+                addLog('info', 'Trimmed leading/trailing whitespace', str, trimmed);
+                str = trimmed;
+            }
+        }
+
+        // 3. Strip null bytes
+        const stripNull = options.stripNullBytes !== false;
+        if (stripNull) {
+            const cleaned = str.replace(/\0/g, '');
+            if (cleaned !== str) {
+                addLog('warn', 'Stripped null bytes from input', str, cleaned);
+                str = cleaned;
+            }
+        }
+
+        // 4. Strip control characters (keep \t and optionally \n)
+        const stripCtrl = options.stripControlChars !== false;
+        if (stripCtrl) {
+            const allowNewlines = options.allowNewlines === true;
+            // eslint-disable-next-line no-control-regex
+            const pattern = allowNewlines
+                ? /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g
+                : /[\x00-\x08\x0A-\x1F\x7F]/g;
+            const cleaned = str.replace(pattern, '');
+            if (cleaned !== str) {
+                addLog('warn', 'Stripped control characters from input', str, cleaned);
+                str = cleaned;
+            }
+        }
+
+        // 5. Normalize Unicode
+        const normalizeUnicode = options.normalizeUnicode !== false;
+        if (normalizeUnicode) {
+            try {
+                const normalized = str.normalize('NFC');
+                if (normalized !== str) {
+                    addLog('info', 'Normalized Unicode to NFC form', str, normalized);
+                    str = normalized;
+                }
+            } catch (err) {
+                addLog('error', `Unicode normalization failed: ${err instanceof Error ? err.message : String(err)}`);
+                errors.push('Input contains invalid Unicode sequences.');
+            }
+        }
+
+        // 6. Length constraints
+        const maxLength = options.maxLength ?? 4096;
+        const minLength = options.minLength ?? 0;
+
+        if (str.length > maxLength) {
+            addLog('error', `Input exceeds maximum length of ${maxLength} characters (got ${str.length})`, str);
+            errors.push(`Input is too long (maximum ${maxLength} characters).`);
+        }
+
+        if (str.length < minLength) {
+            addLog('error', `Input is shorter than minimum length of ${minLength} characters (got ${str.length})`, str);
+            errors.push(`Input is too short (minimum ${minLength} characters).`);
+        }
+
+        // 7. Custom rules
+        if (options.customRules) {
+            for (const rule of options.customRules) {
+                try {
+                    const result = rule.apply(str, field);
+                    if (result !== str) {
+                        addLog('info', `Custom rule "${rule.id}" modified input`, str, result);
+                        str = result;
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    addLog('error', `Custom rule "${rule.id}" rejected input: ${msg}`, str);
+                    errors.push(`Validation rule "${rule.description}" failed: ${msg}`);
+                }
+            }
+        }
+
+        const wasModified = str !== original;
+        if (wasModified && errors.length === 0) {
+            addLog('info', 'Input was sanitized successfully', original, str);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings,
+            logs,
+            wasModified,
+        };
+    }
+
+    // ── Contract ID sanitization ─────────────────────────────
+
+    /**
+     * Sanitize and validate a Stellar contract ID.
+     *
+     * A valid Stellar contract ID starts with 'C' and is exactly 56
+     * alphanumeric uppercase characters (Stellar strkey format).
+     */
+    sanitizeContractId(
+        value: unknown,
+        options: SanitizeContractIdOptions = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'contractId';
+
+        // First apply generic string sanitization
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 56,
+            minLength: 1,
+            trim: true,
+            allowNewlines: false,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue.toUpperCase();
+        const errors = [...base.errors];
+        const logs = [...base.logs];
+
+        if (!/^C[A-Z0-9]{55}$/.test(str)) {
+            const msg = 'Invalid contract ID format (must start with "C" and be 56 uppercase alphanumeric characters)';
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: base.sanitizedValue,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings: base.warnings,
+            logs,
+            wasModified: base.wasModified || str !== base.sanitizedValue,
+        };
+    }
+
+    // ── Network name sanitization ────────────────────────────
+
+    /**
+     * Sanitize and validate a network name.
+     */
+    sanitizeNetworkName(
+        value: unknown,
+        options: SanitizeNetworkOptions = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'network';
+        const allowed = options.allowedNetworks ?? InputSanitizationService.DEFAULT_ALLOWED_NETWORKS;
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 64,
+            minLength: 1,
+            trim: true,
+            allowNewlines: false,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue.toLowerCase();
+        const errors = [...base.errors];
+        const logs = [...base.logs];
+
+        if (!allowed.includes(str)) {
+            const msg = `Unknown network "${str}". Allowed values: ${allowed.join(', ')}`;
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: base.sanitizedValue,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings: base.warnings,
+            logs,
+            wasModified: base.wasModified || str !== base.sanitizedValue,
+        };
+    }
+
+    // ── File path sanitization ───────────────────────────────
+
+    /**
+     * Sanitize and validate a file system path.
+     *
+     * By default, path traversal sequences (`..`) are rejected to prevent
+     * directory traversal attacks.
+     */
+    sanitizePath(
+        value: unknown,
+        options: SanitizePathOptions = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'path';
+        const allowTraversal = options.allowTraversal === true;
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 4096,
+            minLength: 1,
+            trim: true,
+            allowNewlines: false,
+            // Paths may contain control chars on some systems, but we still strip null bytes
+            stripControlChars: true,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue;
+        const errors = [...base.errors];
+        const warnings = [...base.warnings];
+        const logs = [...base.logs];
+
+        // Reject path traversal
+        if (!allowTraversal && /(^|[/\\])\.\.([/\\]|$)/.test(str)) {
+            const msg = 'Path traversal sequences ("..") are not allowed';
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: str,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        // Warn on absolute paths if not allowed
+        if (options.allowAbsolute === false && /^([A-Za-z]:[/\\]|\/)/.test(str)) {
+            const msg = 'Absolute paths are not permitted for this field';
+            logs.push({
+                level: 'warn',
+                field,
+                message: msg,
+                originalValue: str,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.warn(`[${field}] ${msg}`);
+            warnings.push(msg);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings,
+            logs,
+            wasModified: base.wasModified,
+        };
+    }
+
+    // ── JSON sanitization ────────────────────────────────────
+
+    /**
+     * Sanitize and validate a JSON string.
+     *
+     * Parses the JSON, checks depth and key count limits, then
+     * re-serializes to a canonical form.
+     */
+    sanitizeJson(
+        value: unknown,
+        options: SanitizeJsonOptions = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'json';
+        const maxDepth = options.maxDepth ?? 10;
+        const maxKeys = options.maxKeys ?? 100;
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 65536,
+            minLength: 1,
+            trim: true,
+            allowNewlines: true,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const errors = [...base.errors];
+        const warnings = [...base.warnings];
+        const logs = [...base.logs];
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(base.sanitizedValue);
+        } catch (err) {
+            const msg = `Invalid JSON: ${err instanceof Error ? err.message : String(err)}`;
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: base.sanitizedValue,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+            return {
+                valid: false,
+                sanitizedValue: base.sanitizedValue,
+                errors,
+                warnings,
+                logs,
+                wasModified: base.wasModified,
+            };
+        }
+
+        // Depth check
+        const depth = jsonDepth(parsed);
+        if (depth > maxDepth) {
+            const msg = `JSON nesting depth ${depth} exceeds maximum of ${maxDepth}`;
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        // Key count check
+        const keys = maxObjectKeys(parsed);
+        if (keys > maxKeys) {
+            const msg = `JSON object has ${keys} keys which exceeds maximum of ${maxKeys}`;
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        // Re-serialize to canonical form (removes extra whitespace, sorts nothing)
+        const canonical = JSON.stringify(parsed);
+        const wasModified = base.wasModified || canonical !== base.sanitizedValue;
+
+        if (wasModified && errors.length === 0) {
+            logs.push({
+                level: 'info',
+                field,
+                message: 'JSON re-serialized to canonical form',
+                originalValue: base.sanitizedValue,
+                sanitizedValue: canonical,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.info(`[${field}] JSON re-serialized to canonical form`);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: errors.length === 0 ? canonical : base.sanitizedValue,
+            errors,
+            warnings,
+            logs,
+            wasModified,
+        };
+    }
+
+    // ── Function name sanitization ───────────────────────────
+
+    /**
+     * Sanitize a Soroban contract function name.
+     *
+     * Function names must be valid Rust identifiers: start with a letter or
+     * underscore, followed by letters, digits, or underscores.
+     */
+    sanitizeFunctionName(
+        value: unknown,
+        options: { field?: string } = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'functionName';
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 128,
+            minLength: 1,
+            trim: true,
+            allowNewlines: false,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue;
+        const errors = [...base.errors];
+        const logs = [...base.logs];
+
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(str)) {
+            const msg = 'Function name must be a valid identifier (letters, digits, underscores; cannot start with a digit)';
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: str,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings: base.warnings,
+            logs,
+            wasModified: base.wasModified,
+        };
+    }
+
+    // ── Environment variable sanitization ───────────────────
+
+    /**
+     * Sanitize an environment variable name.
+     *
+     * Env var names must consist of uppercase letters, digits, and underscores,
+     * and must not start with a digit.
+     */
+    sanitizeEnvVarName(
+        value: unknown,
+        options: { field?: string } = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'envVarName';
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 256,
+            minLength: 1,
+            trim: true,
+            allowNewlines: false,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue.toUpperCase();
+        const errors = [...base.errors];
+        const logs = [...base.logs];
+
+        if (!/^[A-Z_][A-Z0-9_]*$/.test(str)) {
+            const msg = 'Environment variable name must contain only uppercase letters, digits, and underscores, and must not start with a digit';
+            logs.push({
+                level: 'error',
+                field,
+                message: msg,
+                originalValue: base.sanitizedValue,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.error(`[${field}] ${msg}`);
+            errors.push(msg);
+        }
+
+        return {
+            valid: errors.length === 0,
+            sanitizedValue: str,
+            errors,
+            warnings: base.warnings,
+            logs,
+            wasModified: base.wasModified || str !== base.sanitizedValue,
+        };
+    }
+
+    /**
+     * Sanitize an environment variable value.
+     *
+     * Env var values may contain most printable characters but must not
+     * contain null bytes or unescaped shell metacharacters that could
+     * enable injection.
+     */
+    sanitizeEnvVarValue(
+        value: unknown,
+        options: { field?: string } = {},
+    ): SanitizationResult<string> {
+        const field = options.field ?? 'envVarValue';
+
+        const base = this.sanitizeString(value, {
+            field,
+            maxLength: 32768,
+            trim: false, // preserve intentional leading/trailing spaces in values
+            allowNewlines: true,
+        });
+
+        if (!base.valid) {
+            return base;
+        }
+
+        const str = base.sanitizedValue;
+        const warnings = [...base.warnings];
+        const logs = [...base.logs];
+
+        // Warn if value contains shell metacharacters that could be dangerous
+        // when interpolated without quoting
+        const dangerousChars = /[`$!;&|<>(){}[\]\\]/;
+        if (dangerousChars.test(str)) {
+            const msg = 'Environment variable value contains shell metacharacters; ensure it is properly quoted when used in shell commands';
+            logs.push({
+                level: 'warn',
+                field,
+                message: msg,
+                timestamp: new Date().toISOString(),
+            });
+            this.logger.warn(`[${field}] ${msg}`);
+            warnings.push(msg);
+        }
+
+        return {
+            valid: base.errors.length === 0,
+            sanitizedValue: str,
+            errors: base.errors,
+            warnings,
+            logs,
+            wasModified: base.wasModified,
+        };
+    }
+
+    // ── Batch sanitization ───────────────────────────────────
+
+    /**
+     * Sanitize a record of key-value pairs (e.g., form fields).
+     *
+     * Each value is sanitized with {@link sanitizeString} using the key as
+     * the field name.  Returns a map of field names to their results.
+     */
+    sanitizeFormFields(
+        fields: Record<string, unknown>,
+        perFieldOptions: Record<string, SanitizeStringOptions> = {},
+    ): Record<string, SanitizationResult<string>> {
+        const results: Record<string, SanitizationResult<string>> = {};
+        for (const [key, val] of Object.entries(fields)) {
+            results[key] = this.sanitizeString(val, {
+                field: key,
+                ...(perFieldOptions[key] ?? {}),
+            });
+        }
+        return results;
+    }
+
+    /**
+     * Returns true if all results in a batch are valid.
+     */
+    static allValid(results: Record<string, SanitizationResult>): boolean {
+        return Object.values(results).every(r => r.valid);
+    }
+
+    /**
+     * Collect all errors from a batch of results into a flat array.
+     */
+    static collectErrors(results: Record<string, SanitizationResult>): string[] {
+        return Object.entries(results).flatMap(([field, r]) =>
+            r.errors.map(e => `[${field}] ${e}`),
+        );
+    }
+}

--- a/src/test/inputSanitizationService.test.ts
+++ b/src/test/inputSanitizationService.test.ts
@@ -1,0 +1,592 @@
+// ============================================================
+// src/test/inputSanitizationService.test.ts
+// Unit tests for InputSanitizationService.
+// ============================================================
+
+declare function require(name: string): any;
+declare const process: { exitCode?: number };
+
+const assert = require('assert');
+
+import {
+    InputSanitizationService,
+    SanitizationRule,
+    SanitizationLogger,
+} from '../services/inputSanitizationService';
+
+// ── Silent logger for tests ───────────────────────────────────
+
+class SilentLogger implements SanitizationLogger {
+    info(_msg: string): void { /* noop */ }
+    warn(_msg: string): void { /* noop */ }
+    error(_msg: string): void { /* noop */ }
+}
+
+function makeSanitizer(): InputSanitizationService {
+    return new InputSanitizationService(new SilentLogger());
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeString
+// ══════════════════════════════════════════════════════════
+
+function testSanitizeStringNullInput() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString(null);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, '');
+    assert.strictEqual(r.wasModified, true);
+    console.log('  [ok] sanitizeString: returns empty string for null input');
+}
+
+function testSanitizeStringUndefinedInput() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString(undefined);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, '');
+    console.log('  [ok] sanitizeString: returns empty string for undefined input');
+}
+
+function testSanitizeStringTrimsWhitespace() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('  hello  ');
+    assert.strictEqual(r.sanitizedValue, 'hello');
+    assert.strictEqual(r.wasModified, true);
+    console.log('  [ok] sanitizeString: trims whitespace by default');
+}
+
+function testSanitizeStringNoTrim() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('  hello  ', { trim: false });
+    assert.strictEqual(r.sanitizedValue, '  hello  ');
+    assert.strictEqual(r.wasModified, false);
+    console.log('  [ok] sanitizeString: does not trim when trim=false');
+}
+
+function testSanitizeStringStripsNullBytes() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('hel\0lo');
+    assert.strictEqual(r.sanitizedValue, 'hello');
+    assert.strictEqual(r.wasModified, true);
+    console.log('  [ok] sanitizeString: strips null bytes');
+}
+
+function testSanitizeStringStripsControlChars() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('hel\x01lo');
+    assert.strictEqual(r.sanitizedValue, 'hello');
+    console.log('  [ok] sanitizeString: strips control characters');
+}
+
+function testSanitizeStringPreservesNewlines() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('line1\nline2', { allowNewlines: true });
+    assert.strictEqual(r.sanitizedValue, 'line1\nline2');
+    console.log('  [ok] sanitizeString: preserves newlines when allowNewlines=true');
+}
+
+function testSanitizeStringStripsNewlines() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('line1\nline2');
+    assert.strictEqual(r.sanitizedValue, 'line1line2');
+    console.log('  [ok] sanitizeString: strips newlines when allowNewlines=false (default)');
+}
+
+function testSanitizeStringMaxLength() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('abcdef', { maxLength: 3 });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('too long')));
+    console.log('  [ok] sanitizeString: enforces maxLength');
+}
+
+function testSanitizeStringMinLength() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('ab', { minLength: 5 });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('too short')));
+    console.log('  [ok] sanitizeString: enforces minLength');
+}
+
+function testSanitizeStringValid() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('hello world');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.errors.length, 0);
+    console.log('  [ok] sanitizeString: valid string passes all checks');
+}
+
+function testSanitizeStringCustomRule() {
+    const s = makeSanitizer();
+    const upperRule: SanitizationRule = {
+        id: 'uppercase',
+        description: 'Convert to uppercase',
+        apply: (v: string) => v.toUpperCase(),
+    };
+    const r = s.sanitizeString('hello', { customRules: [upperRule] });
+    assert.strictEqual(r.sanitizedValue, 'HELLO');
+    console.log('  [ok] sanitizeString: applies custom rules');
+}
+
+function testSanitizeStringCustomRuleError() {
+    const s = makeSanitizer();
+    const rejectRule: SanitizationRule = {
+        id: 'reject-all',
+        description: 'Reject everything',
+        apply: () => { throw new Error('Not allowed'); },
+    };
+    const r = s.sanitizeString('hello', { customRules: [rejectRule] });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('Not allowed')));
+    console.log('  [ok] sanitizeString: custom rule error marks result invalid');
+}
+
+function testSanitizeStringProducesLogs() {
+    const s = makeSanitizer();
+    const r = s.sanitizeString('  hello\0  ');
+    assert.ok(r.logs.length > 0);
+    console.log('  [ok] sanitizeString: produces log entries');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeContractId
+// ══════════════════════════════════════════════════════════
+
+const VALID_CONTRACT_ID = 'C' + 'A'.repeat(55);
+
+function testContractIdValid() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId(VALID_CONTRACT_ID);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, VALID_CONTRACT_ID);
+    console.log('  [ok] sanitizeContractId: accepts a valid contract ID');
+}
+
+function testContractIdNormalizesUppercase() {
+    const s = makeSanitizer();
+    const lower = 'c' + 'a'.repeat(55);
+    const r = s.sanitizeContractId(lower);
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, VALID_CONTRACT_ID);
+    console.log('  [ok] sanitizeContractId: normalizes to uppercase');
+}
+
+function testContractIdTooShort() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId('CABC');
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeContractId: rejects ID that is too short');
+}
+
+function testContractIdWrongPrefix() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId('G' + 'A'.repeat(55));
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeContractId: rejects ID that does not start with C');
+}
+
+function testContractIdInvalidChars() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId('C' + 'A'.repeat(54) + '!');
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeContractId: rejects ID with invalid characters');
+}
+
+function testContractIdEmpty() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId('');
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeContractId: rejects empty string');
+}
+
+function testContractIdNull() {
+    const s = makeSanitizer();
+    const r = s.sanitizeContractId(null);
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeContractId: rejects null');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeNetworkName
+// ══════════════════════════════════════════════════════════
+
+function testNetworkTestnet() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeNetworkName('testnet').valid, true);
+    console.log('  [ok] sanitizeNetworkName: accepts testnet');
+}
+
+function testNetworkMainnet() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeNetworkName('mainnet').valid, true);
+    console.log('  [ok] sanitizeNetworkName: accepts mainnet');
+}
+
+function testNetworkNormalizesLowercase() {
+    const s = makeSanitizer();
+    const r = s.sanitizeNetworkName('TESTNET');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, 'testnet');
+    console.log('  [ok] sanitizeNetworkName: normalizes to lowercase');
+}
+
+function testNetworkUnknown() {
+    const s = makeSanitizer();
+    const r = s.sanitizeNetworkName('devnet');
+    assert.strictEqual(r.valid, false);
+    console.log('  [ok] sanitizeNetworkName: rejects unknown network');
+}
+
+function testNetworkCustomAllowed() {
+    const s = makeSanitizer();
+    const r = s.sanitizeNetworkName('devnet', { allowedNetworks: ['devnet', 'testnet'] });
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizeNetworkName: accepts custom allowed networks');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizePath
+// ══════════════════════════════════════════════════════════
+
+function testPathRelative() {
+    const s = makeSanitizer();
+    const r = s.sanitizePath('contracts/my_contract.wasm');
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizePath: accepts a normal relative path');
+}
+
+function testPathTraversalRejected() {
+    const s = makeSanitizer();
+    const r = s.sanitizePath('../etc/passwd');
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('traversal')));
+    console.log('  [ok] sanitizePath: rejects path traversal by default');
+}
+
+function testPathTraversalAllowed() {
+    const s = makeSanitizer();
+    const r = s.sanitizePath('../sibling/file.txt', { allowTraversal: true });
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizePath: allows path traversal when explicitly permitted');
+}
+
+function testPathAbsoluteWarning() {
+    const s = makeSanitizer();
+    const r = s.sanitizePath('/etc/passwd', { allowAbsolute: false });
+    assert.ok(r.warnings.some((w: string) => w.includes('Absolute')));
+    console.log('  [ok] sanitizePath: warns on absolute path when not allowed');
+}
+
+function testPathAbsoluteDefault() {
+    const s = makeSanitizer();
+    const r = s.sanitizePath('/home/user/contracts/my.wasm');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.warnings.length, 0);
+    console.log('  [ok] sanitizePath: accepts absolute path by default');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeJson
+// ══════════════════════════════════════════════════════════
+
+function testJsonValidObject() {
+    const s = makeSanitizer();
+    const r = s.sanitizeJson('{"name":"world"}');
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizeJson: accepts valid JSON object');
+}
+
+function testJsonValidArray() {
+    const s = makeSanitizer();
+    const r = s.sanitizeJson('[1,2,3]');
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizeJson: accepts valid JSON array');
+}
+
+function testJsonInvalid() {
+    const s = makeSanitizer();
+    const r = s.sanitizeJson('{not valid json}');
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('Invalid JSON')));
+    console.log('  [ok] sanitizeJson: rejects invalid JSON');
+}
+
+function testJsonTooDeep() {
+    const s = makeSanitizer();
+    let nested: unknown = 'leaf';
+    for (let i = 0; i < 12; i++) {
+        nested = { child: nested };
+    }
+    const r = s.sanitizeJson(JSON.stringify(nested), { maxDepth: 5 });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('depth')));
+    console.log('  [ok] sanitizeJson: rejects deeply nested JSON');
+}
+
+function testJsonTooManyKeys() {
+    const s = makeSanitizer();
+    const obj: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) { obj[`key${i}`] = i; }
+    const r = s.sanitizeJson(JSON.stringify(obj), { maxKeys: 5 });
+    assert.strictEqual(r.valid, false);
+    assert.ok(r.errors.some((e: string) => e.includes('keys')));
+    console.log('  [ok] sanitizeJson: rejects JSON with too many keys');
+}
+
+function testJsonCanonicalForm() {
+    const s = makeSanitizer();
+    const r = s.sanitizeJson('  {  "a" :  1  }  ');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, '{"a":1}');
+    console.log('  [ok] sanitizeJson: re-serializes to canonical form');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeFunctionName
+// ══════════════════════════════════════════════════════════
+
+function testFunctionNameValid() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('transfer').valid, true);
+    console.log('  [ok] sanitizeFunctionName: accepts valid function name');
+}
+
+function testFunctionNameWithUnderscores() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('get_balance').valid, true);
+    console.log('  [ok] sanitizeFunctionName: accepts function name with underscores');
+}
+
+function testFunctionNameStartsWithUnderscore() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('_internal').valid, true);
+    console.log('  [ok] sanitizeFunctionName: accepts function name starting with underscore');
+}
+
+function testFunctionNameStartsWithDigit() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('1transfer').valid, false);
+    console.log('  [ok] sanitizeFunctionName: rejects function name starting with digit');
+}
+
+function testFunctionNameWithSpaces() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('my function').valid, false);
+    console.log('  [ok] sanitizeFunctionName: rejects function name with spaces');
+}
+
+function testFunctionNameWithSpecialChars() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('transfer!').valid, false);
+    console.log('  [ok] sanitizeFunctionName: rejects function name with special characters');
+}
+
+function testFunctionNameEmpty() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeFunctionName('').valid, false);
+    console.log('  [ok] sanitizeFunctionName: rejects empty string');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeEnvVarName
+// ══════════════════════════════════════════════════════════
+
+function testEnvVarNameValid() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeEnvVarName('MY_API_KEY').valid, true);
+    console.log('  [ok] sanitizeEnvVarName: accepts valid env var name');
+}
+
+function testEnvVarNameNormalizesUppercase() {
+    const s = makeSanitizer();
+    const r = s.sanitizeEnvVarName('my_api_key');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.sanitizedValue, 'MY_API_KEY');
+    console.log('  [ok] sanitizeEnvVarName: normalizes to uppercase');
+}
+
+function testEnvVarNameStartsWithDigit() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeEnvVarName('1KEY').valid, false);
+    console.log('  [ok] sanitizeEnvVarName: rejects name starting with digit');
+}
+
+function testEnvVarNameWithSpaces() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeEnvVarName('MY KEY').valid, false);
+    console.log('  [ok] sanitizeEnvVarName: rejects name with spaces');
+}
+
+function testEnvVarNameWithHyphens() {
+    const s = makeSanitizer();
+    assert.strictEqual(s.sanitizeEnvVarName('MY-KEY').valid, false);
+    console.log('  [ok] sanitizeEnvVarName: rejects name with hyphens');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeEnvVarValue
+// ══════════════════════════════════════════════════════════
+
+function testEnvVarValuePlain() {
+    const s = makeSanitizer();
+    const r = s.sanitizeEnvVarValue('hello world');
+    assert.strictEqual(r.valid, true);
+    console.log('  [ok] sanitizeEnvVarValue: accepts plain value');
+}
+
+function testEnvVarValueMetacharWarning() {
+    const s = makeSanitizer();
+    const r = s.sanitizeEnvVarValue('$(rm -rf /)');
+    assert.strictEqual(r.valid, true); // still valid, just warned
+    assert.ok(r.warnings.some((w: string) => w.includes('metacharacters')));
+    console.log('  [ok] sanitizeEnvVarValue: warns on shell metacharacters');
+}
+
+function testEnvVarValueStripsNullBytes() {
+    const s = makeSanitizer();
+    const r = s.sanitizeEnvVarValue('val\0ue');
+    assert.strictEqual(r.sanitizedValue, 'value');
+    console.log('  [ok] sanitizeEnvVarValue: strips null bytes');
+}
+
+// ══════════════════════════════════════════════════════════
+// sanitizeFormFields
+// ══════════════════════════════════════════════════════════
+
+function testFormFieldsSanitizesAll() {
+    const s = makeSanitizer();
+    const results = s.sanitizeFormFields({
+        name: '  Alice  ',
+        age: '25',
+    });
+    assert.strictEqual(results['name'].sanitizedValue, 'Alice');
+    assert.strictEqual(results['age'].sanitizedValue, '25');
+    console.log('  [ok] sanitizeFormFields: sanitizes all fields');
+}
+
+function testFormFieldsAllValid() {
+    const s = makeSanitizer();
+    const results = s.sanitizeFormFields({ a: 'hello', b: 'world' });
+    assert.strictEqual(InputSanitizationService.allValid(results), true);
+    console.log('  [ok] sanitizeFormFields: allValid returns true when all fields are valid');
+}
+
+function testFormFieldsAllValidFalse() {
+    const s = makeSanitizer();
+    const results = s.sanitizeFormFields(
+        { a: 'hello', b: 'toolong' },
+        { b: { maxLength: 3 } },
+    );
+    assert.strictEqual(InputSanitizationService.allValid(results), false);
+    console.log('  [ok] sanitizeFormFields: allValid returns false when any field is invalid');
+}
+
+function testFormFieldsCollectErrors() {
+    const s = makeSanitizer();
+    const results = s.sanitizeFormFields(
+        { myField: 'x'.repeat(10) },
+        { myField: { maxLength: 5 } },
+    );
+    const errors = InputSanitizationService.collectErrors(results);
+    assert.ok(errors.some((e: string) => e.startsWith('[myField]')));
+    console.log('  [ok] sanitizeFormFields: collectErrors returns prefixed error messages');
+}
+
+// ══════════════════════════════════════════════════════════
+// Test runner
+// ══════════════════════════════════════════════════════════
+
+async function runAll() {
+    console.log('\n══════════════════════════════════════════════════════════');
+    console.log('  InputSanitizationService Tests');
+    console.log('══════════════════════════════════════════════════════════\n');
+
+    const tests = [
+        // sanitizeString
+        testSanitizeStringNullInput,
+        testSanitizeStringUndefinedInput,
+        testSanitizeStringTrimsWhitespace,
+        testSanitizeStringNoTrim,
+        testSanitizeStringStripsNullBytes,
+        testSanitizeStringStripsControlChars,
+        testSanitizeStringPreservesNewlines,
+        testSanitizeStringStripsNewlines,
+        testSanitizeStringMaxLength,
+        testSanitizeStringMinLength,
+        testSanitizeStringValid,
+        testSanitizeStringCustomRule,
+        testSanitizeStringCustomRuleError,
+        testSanitizeStringProducesLogs,
+        // sanitizeContractId
+        testContractIdValid,
+        testContractIdNormalizesUppercase,
+        testContractIdTooShort,
+        testContractIdWrongPrefix,
+        testContractIdInvalidChars,
+        testContractIdEmpty,
+        testContractIdNull,
+        // sanitizeNetworkName
+        testNetworkTestnet,
+        testNetworkMainnet,
+        testNetworkNormalizesLowercase,
+        testNetworkUnknown,
+        testNetworkCustomAllowed,
+        // sanitizePath
+        testPathRelative,
+        testPathTraversalRejected,
+        testPathTraversalAllowed,
+        testPathAbsoluteWarning,
+        testPathAbsoluteDefault,
+        // sanitizeJson
+        testJsonValidObject,
+        testJsonValidArray,
+        testJsonInvalid,
+        testJsonTooDeep,
+        testJsonTooManyKeys,
+        testJsonCanonicalForm,
+        // sanitizeFunctionName
+        testFunctionNameValid,
+        testFunctionNameWithUnderscores,
+        testFunctionNameStartsWithUnderscore,
+        testFunctionNameStartsWithDigit,
+        testFunctionNameWithSpaces,
+        testFunctionNameWithSpecialChars,
+        testFunctionNameEmpty,
+        // sanitizeEnvVarName
+        testEnvVarNameValid,
+        testEnvVarNameNormalizesUppercase,
+        testEnvVarNameStartsWithDigit,
+        testEnvVarNameWithSpaces,
+        testEnvVarNameWithHyphens,
+        // sanitizeEnvVarValue
+        testEnvVarValuePlain,
+        testEnvVarValueMetacharWarning,
+        testEnvVarValueStripsNullBytes,
+        // sanitizeFormFields
+        testFormFieldsSanitizesAll,
+        testFormFieldsAllValid,
+        testFormFieldsAllValidFalse,
+        testFormFieldsCollectErrors,
+    ];
+
+    let passed = 0;
+    let failed = 0;
+
+    for (const test of tests) {
+        try {
+            await test();
+            passed++;
+        } catch (err) {
+            failed++;
+            console.error(`  [FAIL] ${test.name}: ${err instanceof Error ? err.message : String(err)}`);
+            if (process) { process.exitCode = 1; }
+        }
+    }
+
+    console.log(`\n  Results: ${passed} passed, ${failed} failed out of ${tests.length} tests\n`);
+}
+
+runAll().catch(err => {
+    console.error('Test runner error:', err);
+    if (process) { process.exitCode = 1; }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "ES2020",
     "outDir": "out",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "dom"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION

feat: form input sanitization
Closes #105

Summary
Adds a comprehensive InputSanitizationService that sanitizes all user-supplied inputs before they are passed to CLI commands, stored in workspace state, or displayed in the UI. This prevents malicious input, data corruption, and injection attacks.

Changes
src/services/inputSanitizationService.ts — Core sanitization service with 8 methods
src/test/inputSanitizationService.test.ts — 56 unit tests (all passing)
docs/input-sanitization.md — Full API documentation

Modified files
src/commands/simulateTransaction.ts — Contract ID and function name inputs are now sanitized
src/commands/envVariableCommands.ts — Env var names and values are now sanitized
src/extension.ts — Fixed duplicate command declarations and orphaned code blocks that caused TS1128 compile errors
tsconfig.json — Added "dom" to lib for WebView badge components

<img width="501" height="304" alt="Screenshot 2026-02-21 055340" src="https://github.com/user-attachments/assets/fda1ce2b-824b-48ce-aed9-f0eaaff6d524" />

Test results
Results: 56 passed, 0 failed out of 56 tests