### PR TITLE
feat: show inline compiler errors in monaco (#309)

### DIFF
--- a/ide/src/test/cargoParser.test.ts
+++ b/ide/src/test/cargoParser.test.ts
@@ -17,13 +17,13 @@ import {
 describe("mapPathToVirtualId", () => {
   it("maps absolute backend path to virtual ID", () => {
     expect(mapPathToVirtualId("/workspace/hello_world/src/lib.rs", "hello_world")).toBe(
-      "hello_world/src/lib.rs"
+      "hello_world/lib.rs"
     );
   });
 
   it("handles relative src/ paths", () => {
     expect(mapPathToVirtualId("src/lib.rs", "hello_world")).toBe(
-      "hello_world/src/lib.rs"
+      "hello_world/lib.rs"
     );
   });
 
@@ -86,7 +86,7 @@ describe("parseCargoLine", () => {
     const result = parseCargoLine(line, "hello_world");
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      fileId: "hello_world/src/lib.rs",
+      fileId: "hello_world/lib.rs",
       line: 12,
       column: 9,
       endLine: 12,
@@ -204,7 +204,7 @@ describe("parseCargoOutput", () => {
   it("maps src/lib.rs errors to virtual file IDs", () => {
     const line = makeCompilerMessage({});
     const result = parseCargoOutput(line, "hello_world");
-    expect(result[0].fileId).toBe("hello_world/src/lib.rs");
+    expect(result[0].fileId).toBe("hello_world/lib.rs");
   });
 });
 

--- a/ide/src/utils/cargoParser.ts
+++ b/ide/src/utils/cargoParser.ts
@@ -92,7 +92,8 @@ export function mapPathToVirtualId(
   if (!normalised.startsWith("/") && !normalised.includes("/src/")) {
     // Handle relative paths like "src/lib.rs" → "hello_world/src/lib.rs"
     if (normalised.startsWith("src/")) {
-      return `${contractName}/${normalised}`;
+      // IDE virtual layout strips the `src/` folder (e.g. `hello_world/lib.rs`).
+      return `${contractName}/${normalised.replace(/^src\//, "")}`;
     }
     return normalised;
   }
@@ -100,7 +101,10 @@ export function mapPathToVirtualId(
   // Extract the filename after the last src/ segment
   const srcMatch = normalised.match(/\/src\/(.+)$/);
   if (srcMatch) {
-    return `${contractName}/src/${srcMatch[1]}`;
+    // In the IDE virtual file tree, contract files live directly under
+    // `<contractName>/...` (no `src/` folder). Strip the `src/` segment so
+    // diagnostics match the active Monaco model's `fileId`.
+    return `${contractName}/${srcMatch[1]}`;
   }
 
   // Fallback: just use the basename


### PR DESCRIPTION
## Summary
Enabled inline compiler diagnostics as Monaco red underlines (“squiggly” markers) by fixing the mapping between parsed cargo diagnostics file paths and the IDE’s virtual file IDs used by the editor models.

## What was implemented
- **Diagnostics → Monaco markers integration (already present)**
  - `ide/src/store/useDiagnosticsStore.ts`: global Zustand store for parsed diagnostics
  - `ide/src/components/editor/CodeEditor.tsx`: filters diagnostics for the active Monaco model and calls `monaco.editor.setModelMarkers(...)`
  - Severity mapping already followed Monaco’s levels (`error`, `warning`, `info`, `hint`)
- **Critical fix: correct `fileId` mapping**
  - `ide/src/utils/cargoParser.ts`:
    - Updated `mapPathToVirtualId()` so rust paths like `/workspace/<contract>/src/lib.rs` map to the IDE virtual model path `<contract>/lib.rs` (the IDE sample contract tree does not include a `src/` folder).
    - Also updated relative handling for `src/...` paths.

## Why this works
`CodeEditor.tsx` only shows markers for diagnostics where `d.fileId === activeTabPath.join("/")`.
Previously the parser produced file IDs like `hello_world/src/lib.rs`, so Monaco had no matching markers for `hello_world/lib.rs`.

## Testing
- `cd ide`
- `npm test` (vitest) ✅
- `npm run build` ✅

Closes #309