### PR TITLE
security: wasm-sri-verification  Closes #589

### DIFF
--- a/ide/package.json
+++ b/ide/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "sri": "node scripts/generate-sri.mjs",
+    "build": "npm run sri && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",

--- a/ide/public/sri-manifest.json
+++ b/ide/public/sri-manifest.json
@@ -1,0 +1,8 @@
+{
+  "generated": "2026-04-23T10:16:18.069Z",
+  "algorithm": "sha384",
+  "assets": {
+    "/workers/compile.worker.js": "sha384-8lA/RqADmaMFkngx3RJMJ+RplYG61czHHiKr4RL8pXEq0jot7Z7gnJTpPG+RG+/t",
+    "/workers/local-compiler.worker.js": "sha384-kjOvRmxz3OfwJur16sOtpaPDSRmYJDTqI2I32Hex0DX2ClEs/xUYcB6qFUcSiyi+"
+  }
+}

--- a/ide/public/workers/local-compiler.worker.js
+++ b/ide/public/workers/local-compiler.worker.js
@@ -239,6 +239,42 @@ const cancelTokens = new Map();
 let compilerState = 'idle';
 let realCompilerModule = null;
 
+// --- SRI Verifier inside worker ---
+let _workerManifest = null;
+async function fetchWithWorkerSRI(url) {
+  const resp = await fetch(url, { cache: 'no-store' });
+  if (!resp.ok) throw new Error('Fetch failed');
+  const buf = await resp.arrayBuffer();
+  
+  if (!_workerManifest) {
+    try {
+      const mResp = await fetch('/sri-manifest.json', { cache: 'no-store' });
+      if (mResp.ok) _workerManifest = await mResp.json();
+    } catch {
+      // Ignore
+    }
+  }
+  if (!_workerManifest) return buf;
+
+  let urlKey;
+  try { urlKey = new URL(url, "https://localhost").pathname; } catch { urlKey = url; }
+  
+  const expectedSRI = _workerManifest.assets[urlKey];
+  if (!expectedSRI) return buf;
+
+  const hashBuffer = await crypto.subtle.digest('SHA-384', buf);
+  const bytes = new Uint8Array(hashBuffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  const actualSRI = 'sha384-' + btoa(binary);
+
+  if (actualSRI !== expectedSRI) {
+    self.postMessage({ type: 'sri-error', url, expected: expectedSRI, actual: actualSRI });
+    throw new Error('SRI check failed');
+  }
+  return buf;
+}
+
 async function initCompiler() {
   if (compilerState === 'ready') return true;
   if (compilerState === 'loading') return false;
@@ -250,13 +286,15 @@ async function initCompiler() {
   const realUrl = (typeof globalThis !== 'undefined' && globalThis.STELLAR_RUSTC_WASM_URL) || null;
   if (realUrl) {
     try {
-      const resp = await fetch(realUrl);
-      const buf = await resp.arrayBuffer();
+      const buf = await fetchWithWorkerSRI(realUrl);
       realCompilerModule = await WebAssembly.compile(buf);
       compilerState = 'ready';
       postStatus('ready', estimateMemoryMb() ?? 480);
       return true;
     } catch (e) {
+      if (e && e.message === 'SRI check failed') {
+        throw e; // Do not fall through on security error
+      }
       // Fall through to demo mode
     }
   }
@@ -352,6 +390,9 @@ self.addEventListener('message', async (e) => {
         self.postMessage({ type: 'done', id, ok: false, output: fullOutput, wasmBase64: null });
       }
     } catch (err) {
+      if (err && err.message === 'SRI check failed') {
+        return; // Main thread will terminate the worker
+      }
       const message = (err && err.message) || 'Local compiler error';
       fullOutput += `\nfatal error: ${message}\n`;
       self.postMessage({ type: 'chunk', id, data: `\nfatal error: ${message}\n` });

--- a/ide/scripts/generate-sri.mjs
+++ b/ide/scripts/generate-sri.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * generate-sri.mjs
+ *
+ * Build-time Subresource Integrity (SRI) hash generator.
+ *
+ * Scans:
+ *   • public/workers/*.js   — Web Worker scripts
+ *   • public/**\/*.wasm      — Any WASM binaries present in public/
+ *
+ * For each asset computes a SHA-384 digest and writes a manifest to
+ * public/sri-manifest.json so SecureFetcher.ts can verify them at runtime.
+ *
+ * Usage:
+ *   node scripts/generate-sri.mjs
+ *
+ * Output format (public/sri-manifest.json):
+ * {
+ *   "generated": "<ISO timestamp>",
+ *   "algorithm": "sha384",
+ *   "assets": {
+ *     "/workers/compile.worker.js": "sha384-<base64url>",
+ *     ...
+ *   }
+ * }
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const IDE_ROOT = join(__dirname, "..");
+const PUBLIC_DIR = join(IDE_ROOT, "public");
+const MANIFEST_PATH = join(PUBLIC_DIR, "sri-manifest.json");
+
+// ─── Collect candidate files ─────────────────────────────────────────────────
+
+/** Recursively walk a directory and return absolute paths of matching files. */
+function walkDir(dir, predicate, results = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkDir(abs, predicate, results);
+    } else if (predicate(entry)) {
+      results.push(abs);
+    }
+  }
+  return results;
+}
+
+const isWorkerOrWasm = (name) =>
+  name.endsWith(".worker.js") || name.endsWith(".wasm");
+
+const candidates = walkDir(PUBLIC_DIR, isWorkerOrWasm);
+
+if (candidates.length === 0) {
+  console.warn(
+    "[SRI] No worker or WASM assets found under public/. Manifest will be empty."
+  );
+}
+
+// ─── Hash each file ───────────────────────────────────────────────────────────
+
+console.log("[SRI] Scanning public/ for WASM and worker assets...");
+
+const assets = {};
+
+for (const abs of candidates) {
+  const bytes = readFileSync(abs);
+  const digest = createHash("sha384").update(bytes).digest("base64");
+  const sri = `sha384-${digest}`;
+
+  // Convert absolute path → URL path relative to public/
+  const rel = "/" + relative(PUBLIC_DIR, abs).replace(/\\/g, "/");
+
+  assets[rel] = sri;
+  console.log(`[SRI] ${rel.padEnd(42)} → ${sri.slice(0, 30)}...`);
+}
+
+// ─── Write manifest ───────────────────────────────────────────────────────────
+
+const manifest = {
+  generated: new Date().toISOString(),
+  algorithm: "sha384",
+  assets,
+};
+
+writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+
+const count = Object.keys(assets).length;
+console.log(
+  `[SRI] Manifest written to public/sri-manifest.json (${count} entr${count === 1 ? "y" : "ies"})`
+);

--- a/ide/src/hooks/useCompilationWorker.ts
+++ b/ide/src/hooks/useCompilationWorker.ts
@@ -59,6 +59,11 @@ export function useCompilationWorker(): UseCompilationWorkerResult {
         return await getWorker().compile(id, options.url, options.payload, (raw) => {
           options.onChunk(formatTerminalChunk(raw));
         });
+      } catch (err: any) {
+        if (err.name === 'SRIIntegrityError') {
+          options.onChunk(formatTerminalChunk(err.message + '\n'));
+        }
+        throw err;
       } finally {
         if (activeIdRef.current === id) {
           activeIdRef.current = null;

--- a/ide/src/lib/compilationWorker.ts
+++ b/ide/src/lib/compilationWorker.ts
@@ -20,6 +20,7 @@ export type WorkerOutbound =
   | { type: 'done'; id: string; ok: boolean; status?: number; output: string; wasmBase64?: string }
   | { type: 'error'; id: string; message: string }
   | { type: 'cancelled'; id: string }
+  | { type: 'sri-error'; url: string; expected: string; actual: string }
   | { type: 'status'; phase: string; memoryMb?: number };
 
 export interface CompileResult {
@@ -88,6 +89,18 @@ export class CompilationWorker {
       case 'status':
         // Status updates are informational; could be logged or forwarded if needed
         break;
+
+      case 'sri-error': {
+        const sriErr = new Error(`[security] WASM integrity check failed for: ${msg.url}\n[security] Expected: ${msg.expected} | Got: ${msg.actual}\n[security] Build aborted to prevent execution of potentially tampered code.`);
+        sriErr.name = "SRIIntegrityError";
+        for (const job of this.jobs.values()) {
+          job.reject(sriErr);
+        }
+        this.jobs.clear();
+        this.worker?.terminate();
+        this.worker = null;
+        break;
+      }
     }
   }
 

--- a/ide/src/utils/SecureFetcher.ts
+++ b/ide/src/utils/SecureFetcher.ts
@@ -1,0 +1,186 @@
+/**
+ * SecureFetcher.ts
+ *
+ * Fetches a remote resource (primarily WASM binaries and worker scripts) and
+ * verifies its SHA-384 integrity against the build-time SRI manifest before
+ * returning the bytes to the caller.
+ *
+ * Key guarantees:
+ *  • If the manifest lists a hash for the URL and it does NOT match → throws
+ *    SRIIntegrityError and NEVER returns the (potentially tampered) bytes.
+ *  • If the manifest has no entry for the URL (e.g. dev mode, unlisted asset)
+ *    → logs a console.warn and returns the bytes unverified so development
+ *    is not blocked.
+ *  • The manifest is fetched once and cached in module memory; call
+ *    clearSRICache() to force a re-fetch (useful in tests).
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SRIManifest {
+  generated: string;
+  algorithm: string;
+  assets: Record<string, string>; // URL path → "sha384-<base64>"
+}
+
+export interface SecureFetchOptions {
+  /** Override the manifest URL (defaults to /sri-manifest.json). */
+  manifestUrl?: string;
+  /** If true, skip SRI verification even when a hash is present. NEVER use in production. */
+  bypassVerification?: boolean;
+}
+
+// ─── Custom error ─────────────────────────────────────────────────────────────
+
+export class SRIIntegrityError extends Error {
+  readonly url: string;
+  readonly expected: string;
+  readonly actual: string;
+
+  constructor(url: string, expected: string, actual: string) {
+    super(
+      `[SRI] Integrity check FAILED for "${url}".\n` +
+        `  Expected: ${expected}\n` +
+        `  Received: ${actual}\n` +
+        `  Aborting load — resource may have been tampered with.`
+    );
+    this.name = "SRIIntegrityError";
+    this.url = url;
+    this.expected = expected;
+    this.actual = actual;
+    // Maintain proper prototype chain for `instanceof` checks
+    Object.setPrototypeOf(this, SRIIntegrityError.prototype);
+  }
+}
+
+// ─── Module-level manifest cache ─────────────────────────────────────────────
+
+let _manifestCache: SRIManifest | null = null;
+let _manifestUrl: string = "/sri-manifest.json";
+
+/**
+ * Load (and cache) the SRI manifest from the given URL.
+ * Subsequent calls return the cached copy unless clearSRICache() is called.
+ */
+export async function loadSRIManifest(
+  manifestUrl: string = "/sri-manifest.json"
+): Promise<SRIManifest | null> {
+  if (_manifestCache && manifestUrl === _manifestUrl) {
+    return _manifestCache;
+  }
+
+  _manifestUrl = manifestUrl;
+
+  try {
+    const res = await fetch(manifestUrl, { cache: "no-store" });
+    if (!res.ok) {
+      console.warn(
+        `[SRI] Could not load manifest from ${manifestUrl} (HTTP ${res.status}). ` +
+          `Running without integrity verification.`
+      );
+      return null;
+    }
+    _manifestCache = (await res.json()) as SRIManifest;
+    return _manifestCache;
+  } catch (err) {
+    console.warn(
+      `[SRI] Failed to fetch manifest: ${(err as Error).message}. ` +
+        `Running without integrity verification.`
+    );
+    return null;
+  }
+}
+
+/** Reset the cached manifest so the next call to loadSRIManifest re-fetches. */
+export function clearSRICache(): void {
+  _manifestCache = null;
+}
+
+// ─── SHA-384 digest helper ────────────────────────────────────────────────────
+
+async function computeSHA384Base64(buffer: ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-384", buffer);
+  const bytes = new Uint8Array(hashBuffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+// ─── Main API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a resource and verify its SHA-384 integrity against the SRI manifest.
+ *
+ * @param url     The URL to fetch (absolute or relative).
+ * @param options Optional configuration.
+ * @returns       The verified ArrayBuffer of the response body.
+ * @throws        {SRIIntegrityError} if the hash does not match.
+ */
+export async function fetchWithSRI(
+  url: string,
+  options: SecureFetchOptions = {}
+): Promise<ArrayBuffer> {
+  const { manifestUrl = "/sri-manifest.json", bypassVerification = false } =
+    options;
+
+  // 1. Fetch the resource (always cache-busted so we get fresh bytes)
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(
+      `[SRI] Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+
+  // 2. Short-circuit if bypass is requested (tests / local dev only)
+  if (bypassVerification) {
+    console.warn(
+      `[SRI] Integrity verification BYPASSED for "${url}". Do not use in production.`
+    );
+    return buffer;
+  }
+
+  // 3. Load the manifest
+  const manifest = await loadSRIManifest(manifestUrl);
+
+  if (!manifest) {
+    // No manifest available — warn and return unverified
+    console.warn(
+      `[SRI] No manifest available. Returning "${url}" unverified. ` +
+        `Run "npm run sri" to generate integrity hashes.`
+    );
+    return buffer;
+  }
+
+  // 4. Derive the URL key used in the manifest (just the pathname)
+  let urlKey: string;
+  try {
+    urlKey = new URL(url, "https://localhost").pathname;
+  } catch {
+    urlKey = url;
+  }
+
+  const expectedSRI = manifest.assets[urlKey];
+
+  if (!expectedSRI) {
+    // No entry for this URL — graceful degradation
+    console.warn(
+      `[SRI] No manifest entry for "${urlKey}". Returning bytes unverified. ` +
+        `Run "npm run sri" to include this asset.`
+    );
+    return buffer;
+  }
+
+  // 5. Compute actual hash and compare
+  const actualBase64 = await computeSHA384Base64(buffer);
+  const actualSRI = `sha384-${actualBase64}`;
+
+  if (actualSRI !== expectedSRI) {
+    throw new SRIIntegrityError(url, expectedSRI, actualSRI);
+  }
+
+  return buffer;
+}

--- a/ide/src/utils/__tests__/SecureFetcher.test.ts
+++ b/ide/src/utils/__tests__/SecureFetcher.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  fetchWithSRI,
+  loadSRIManifest,
+  clearSRICache,
+  SRIIntegrityError,
+} from "../SecureFetcher";
+
+const MOCK_MANIFEST = {
+  generated: "2026-04-23T12:00:00Z",
+  algorithm: "sha384",
+  assets: {
+    "/test.wasm": "sha384-mockhash",
+  },
+};
+
+describe("SecureFetcher", () => {
+  beforeEach(() => {
+    clearSRICache();
+    vi.restoreAllMocks();
+  });
+
+  it("loads the manifest and caches it", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => MOCK_MANIFEST,
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const m1 = await loadSRIManifest();
+    expect(m1).toEqual(MOCK_MANIFEST);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const m2 = await loadSRIManifest();
+    expect(m2).toEqual(MOCK_MANIFEST);
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // Cached
+  });
+
+  it("bypasses verification when requested", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(4),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const buf = await fetchWithSRI("/bypass.wasm", {
+      bypassVerification: true,
+    });
+    expect(buf.byteLength).toBe(4);
+  });
+
+  it("returns unverified if manifest fails to load", async () => {
+    const fetchSpy = vi.fn().mockImplementation((url) => {
+      if (url === "/sri-manifest.json") {
+        return Promise.resolve({ ok: false, status: 404 });
+      }
+      return Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const buf = await fetchWithSRI("/test.wasm");
+    expect(buf.byteLength).toBe(8);
+  });
+
+  it("throws SRIIntegrityError on mismatch", async () => {
+    const fetchSpy = vi.fn().mockImplementation((url) => {
+      if (url === "/sri-manifest.json") {
+        return Promise.resolve({ ok: true, json: async () => MOCK_MANIFEST });
+      }
+      return Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    vi.stubGlobal("crypto", {
+      subtle: {
+        digest: async () => new Uint8Array([1, 2, 3]).buffer,
+      },
+    });
+
+    await expect(fetchWithSRI("/test.wasm")).rejects.toThrow(
+      SRIIntegrityError
+    );
+  });
+
+  it("returns verified buffer on match", async () => {
+    const fetchSpy = vi.fn().mockImplementation((url) => {
+      if (url === "/sri-manifest.json") {
+        return Promise.resolve({ ok: true, json: async () => MOCK_MANIFEST });
+      }
+      return Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const mockHashBase64 = "AQID"; // [1,2,3] base64 encoded
+    MOCK_MANIFEST.assets["/test.wasm"] = `sha384-${mockHashBase64}`;
+
+    vi.stubGlobal("crypto", {
+      subtle: {
+        digest: async () => new Uint8Array([1, 2, 3]).buffer,
+      },
+    });
+
+    const buf = await fetchWithSRI("/test.wasm");
+    expect(buf.byteLength).toBe(8);
+  });
+});


### PR DESCRIPTION
     Closes #589
- Add scripts/generate-sri.mjs: scans public/ for wasm/workers and outputs sha384 to sri-manifest.json
- Add src/utils/SecureFetcher.ts: fetches remote assets, enforces SRI check against manifest cache
- Modify public/workers/local-compiler.worker.js: verifies integrity of WASM before instantiation
- Modify src/lib/compilationWorker.ts: handles 'sri-error' from worker, aborts queue
- Modify src/hooks/useCompilationWorker.ts: surfaces SRI integrity error to terminal
- Modify package.json: hooks 'npm run sri' to run automatically before 'next build'
