### PR TITLE
feat: standardized-error-handling

### DIFF
--- a/ide/src/lib/error/AppError.ts
+++ b/ide/src/lib/error/AppError.ts
@@ -1,0 +1,271 @@
+/**
+ * src/lib/error/AppError.ts
+ * ============================================================
+ * Standardized Error Handling Framework — Domain-Specific Error Classes
+ *
+ * Provides a hierarchy of typed `AppError` subclasses that carry:
+ *  - A machine-readable `code` for programmatic handling
+ *  - A `domain` tag (ui | compiler | network | contract | auth)
+ *  - An optional `severity` for toast routing
+ *  - Optional metadata for logging / display enrichment
+ *
+ * Usage:
+ *   throw new CompilerError("WASM_BUILD_FAILED", "cargo build exited with code 1");
+ *   throw new NetworkError("RPC_TIMEOUT", "Soroban RPC did not respond in 30 s");
+ * ============================================================
+ */
+
+// ---------------------------------------------------------------------------
+// Domain literals
+// ---------------------------------------------------------------------------
+
+export type ErrorDomain = "ui" | "compiler" | "network" | "contract" | "auth";
+export type ErrorSeverity = "error" | "warning" | "info";
+
+// ---------------------------------------------------------------------------
+// Shared metadata bag
+// ---------------------------------------------------------------------------
+
+export interface AppErrorMeta {
+  /** Raw cause — original Error or response payload */
+  cause?: unknown;
+  /** Additional key/value context for logging */
+  context?: Record<string, unknown>;
+  /** HTTP status, Soroban host code, etc. */
+  statusCode?: number;
+  /** Actionable suggestions shown alongside the toast */
+  suggestions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Base class
+// ---------------------------------------------------------------------------
+
+/**
+ * Base class for all application-level errors.
+ *
+ * All subclasses extend this so consumers can distinguish app errors from
+ * unexpected built-in errors with a simple `instanceof AppError` check.
+ */
+export class AppError extends Error {
+  /** Machine-readable code (SCREAMING_SNAKE_CASE) */
+  readonly code: string;
+  /** Domain that originated the error */
+  readonly domain: ErrorDomain;
+  /** How serious the error is */
+  readonly severity: ErrorSeverity;
+  /** Optional enrichment metadata */
+  readonly meta: AppErrorMeta;
+  /** ISO timestamp when the error was created */
+  readonly timestamp: string;
+
+  constructor(
+    code: string,
+    message: string,
+    domain: ErrorDomain,
+    severity: ErrorSeverity = "error",
+    meta: AppErrorMeta = {}
+  ) {
+    super(message);
+
+    // Restore prototype chain (required when extending built-ins in TypeScript)
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    this.name = new.target.name;
+    this.code = code;
+    this.domain = domain;
+    this.severity = severity;
+    this.meta = meta;
+    this.timestamp = new Date().toISOString();
+
+    // Preserve original stack when a cause is provided
+    if (meta.cause instanceof Error && meta.cause.stack) {
+      this.stack = `${this.stack}\nCaused by: ${meta.cause.stack}`;
+    }
+  }
+
+  /** Serialise to a plain object, suitable for JSON logging. */
+  toJSON(): Record<string, unknown> {
+    return {
+      name: this.name,
+      code: this.code,
+      domain: this.domain,
+      severity: this.severity,
+      message: this.message,
+      timestamp: this.timestamp,
+      statusCode: this.meta.statusCode,
+      context: this.meta.context,
+      suggestions: this.meta.suggestions,
+    };
+  }
+
+  /** User-facing title derived from the code (e.g. "RPC_TIMEOUT" → "Rpc Timeout") */
+  get title(): string {
+    return this.code
+      .split("_")
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+      .join(" ");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Domain sub-classes
+// ---------------------------------------------------------------------------
+
+/**
+ * Errors originating from the UI layer:
+ *   - invalid user input
+ *   - form validation failures
+ *   - unsupported browser features
+ */
+export class UIError extends AppError {
+  constructor(code: string, message: string, meta: AppErrorMeta = {}) {
+    super(code, message, "ui", meta.cause instanceof Error ? "warning" : "error", meta);
+  }
+}
+
+/**
+ * Errors originating from the Rust/WASM compilation pipeline:
+ *   - cargo build failures
+ *   - clippy / rustfmt errors
+ *   - WASM upload failures
+ */
+export class CompilerError extends AppError {
+  /** Raw compiler stderr/stdout output */
+  readonly rawOutput?: string;
+
+  constructor(
+    code: string,
+    message: string,
+    rawOutput?: string,
+    meta: AppErrorMeta = {}
+  ) {
+    super(code, message, "compiler", "error", {
+      ...meta,
+      context: { ...meta.context, rawOutput },
+    });
+    this.rawOutput = rawOutput;
+  }
+}
+
+/**
+ * Errors originating from network communication:
+ *   - Soroban RPC failures
+ *   - Horizon fetch errors
+ *   - WebSocket disconnections
+ *   - General fetch / CORS issues
+ */
+export class NetworkError extends AppError {
+  constructor(code: string, message: string, meta: AppErrorMeta = {}) {
+    // Derive severity: timeouts / rate-limits are warnings; everything else is errors
+    const severity: ErrorSeverity =
+      code === "RPC_TIMEOUT" || code === "RATE_LIMIT_EXCEEDED"
+        ? "warning"
+        : "error";
+    super(code, message, "network", severity, meta);
+  }
+}
+
+/**
+ * Errors originating from Soroban smart-contract interactions:
+ *   - host-function errors
+ *   - simulation / invocation failures
+ *   - XDR parsing issues
+ *   - contract instantiation failures
+ */
+export class ContractError extends AppError {
+  /** Soroban host error code (numeric), if available */
+  readonly hostCode?: number;
+
+  constructor(
+    code: string,
+    message: string,
+    hostCode?: number,
+    meta: AppErrorMeta = {}
+  ) {
+    super(code, message, "contract", "error", {
+      ...meta,
+      statusCode: hostCode ?? meta.statusCode,
+      context: { ...meta.context, hostCode },
+    });
+    this.hostCode = hostCode;
+  }
+}
+
+/**
+ * Errors originating from authentication / identity management:
+ *   - wallet connection failures
+ *   - missing / expired sessions
+ *   - key-pair permission denials
+ */
+export class AuthError extends AppError {
+  constructor(code: string, message: string, meta: AppErrorMeta = {}) {
+    super(code, message, "auth", "error", meta);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Well-known code constants (prevents magic strings in call-sites)
+// ---------------------------------------------------------------------------
+
+export const ErrorCodes = {
+  // UI
+  INVALID_INPUT: "INVALID_INPUT",
+  UNSUPPORTED_BROWSER: "UNSUPPORTED_BROWSER",
+  FORM_VALIDATION_FAILED: "FORM_VALIDATION_FAILED",
+
+  // Compiler
+  WASM_BUILD_FAILED: "WASM_BUILD_FAILED",
+  WASM_UPLOAD_FAILED: "WASM_UPLOAD_FAILED",
+  CLIPPY_FAILED: "CLIPPY_FAILED",
+  RUSTFMT_FAILED: "RUSTFMT_FAILED",
+  TEST_RUN_FAILED: "TEST_RUN_FAILED",
+  CARGO_AUDIT_FAILED: "CARGO_AUDIT_FAILED",
+  FUZZ_FAILED: "FUZZ_FAILED",
+
+  // Network
+  RPC_TIMEOUT: "RPC_TIMEOUT",
+  RPC_UNREACHABLE: "RPC_UNREACHABLE",
+  RPC_INVALID_RESPONSE: "RPC_INVALID_RESPONSE",
+  RATE_LIMIT_EXCEEDED: "RATE_LIMIT_EXCEEDED",
+  HTTP_ERROR: "HTTP_ERROR",
+  FETCH_FAILED: "FETCH_FAILED",
+
+  // Contract
+  CONTRACT_SIMULATION_FAILED: "CONTRACT_SIMULATION_FAILED",
+  CONTRACT_INVOCATION_FAILED: "CONTRACT_INVOCATION_FAILED",
+  CONTRACT_INSTANTIATION_FAILED: "CONTRACT_INSTANTIATION_FAILED",
+  CONTRACT_NOT_FOUND: "CONTRACT_NOT_FOUND",
+  CONTRACT_HOST_ERROR: "CONTRACT_HOST_ERROR",
+  XDR_PARSE_FAILED: "XDR_PARSE_FAILED",
+
+  // Auth
+  WALLET_CONNECTION_FAILED: "WALLET_CONNECTION_FAILED",
+  SESSION_EXPIRED: "SESSION_EXPIRED",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  IDENTITY_NOT_FOUND: "IDENTITY_NOT_FOUND",
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+// ---------------------------------------------------------------------------
+// Type-guard helpers
+// ---------------------------------------------------------------------------
+
+export const isAppError = (err: unknown): err is AppError =>
+  err instanceof AppError;
+
+export const isUIError = (err: unknown): err is UIError =>
+  err instanceof UIError;
+
+export const isCompilerError = (err: unknown): err is CompilerError =>
+  err instanceof CompilerError;
+
+export const isNetworkError = (err: unknown): err is NetworkError =>
+  err instanceof NetworkError;
+
+export const isContractError = (err: unknown): err is ContractError =>
+  err instanceof ContractError;
+
+export const isAuthError = (err: unknown): err is AuthError =>
+  err instanceof AuthError;

--- a/ide/src/lib/error/__tests__/AppError.test.ts
+++ b/ide/src/lib/error/__tests__/AppError.test.ts
@@ -1,0 +1,206 @@
+/**
+ * src/lib/error/__tests__/AppError.test.ts
+ * ============================================================
+ * Unit tests for the Standardized Error Handling Framework
+ * ============================================================
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  AppError,
+  UIError,
+  CompilerError,
+  NetworkError,
+  ContractError,
+  AuthError,
+  ErrorCodes,
+  isAppError,
+  isUIError,
+  isCompilerError,
+  isNetworkError,
+  isContractError,
+  isAuthError,
+} from "../AppError";
+
+// ---------------------------------------------------------------------------
+// AppError base class
+// ---------------------------------------------------------------------------
+
+describe("AppError — base class", () => {
+  it("creates an instance with all required fields", () => {
+    const err = new AppError("TEST_CODE", "Something went wrong", "ui", "error");
+
+    expect(err.code).toBe("TEST_CODE");
+    expect(err.message).toBe("Something went wrong");
+    expect(err.domain).toBe("ui");
+    expect(err.severity).toBe("error");
+    expect(err.name).toBe("AppError");
+    expect(err.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("derives a human-readable title from the code", () => {
+    const err = new AppError("RPC_TIMEOUT", "msg", "network");
+    expect(err.title).toBe("Rpc Timeout");
+  });
+
+  it("serialises to plain JSON without circular refs", () => {
+    const err = new AppError("TEST", "msg", "network", "warning", {
+      statusCode: 503,
+      suggestions: ["Try again"],
+    });
+    const json = err.toJSON();
+
+    expect(json.code).toBe("TEST");
+    expect(json.severity).toBe("warning");
+    expect(json.statusCode).toBe(503);
+    expect(json.suggestions).toContain("Try again");
+  });
+
+  it("preserves the cause stack when given an Error cause", () => {
+    const cause = new Error("original problem");
+    const err = new AppError("WRAPPED", "wrapped message", "network", "error", { cause });
+
+    expect(err.stack).toContain("Caused by:");
+    expect(err.meta.cause).toBe(cause);
+  });
+
+  it("instanceof AppError is true for all subclasses", () => {
+    expect(new UIError("X", "m") instanceof AppError).toBe(true);
+    expect(new CompilerError("X", "m") instanceof AppError).toBe(true);
+    expect(new NetworkError("X", "m") instanceof AppError).toBe(true);
+    expect(new ContractError("X", "m") instanceof AppError).toBe(true);
+    expect(new AuthError("X", "m") instanceof AppError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UIError
+// ---------------------------------------------------------------------------
+
+describe("UIError", () => {
+  it("has domain = ui", () => {
+    const err = new UIError("INVALID_INPUT", "Field is required");
+    expect(err.domain).toBe("ui");
+    expect(err.name).toBe("UIError");
+  });
+
+  it("type-guard isUIError works", () => {
+    expect(isUIError(new UIError("X", "y"))).toBe(true);
+    expect(isUIError(new NetworkError("X", "y"))).toBe(false);
+    expect(isUIError(new Error("plain"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CompilerError
+// ---------------------------------------------------------------------------
+
+describe("CompilerError", () => {
+  it("stores rawOutput", () => {
+    const err = new CompilerError(
+      ErrorCodes.WASM_BUILD_FAILED,
+      "cargo build failed",
+      "error[E0308]: mismatched types"
+    );
+    expect(err.rawOutput).toBe("error[E0308]: mismatched types");
+    expect(err.domain).toBe("compiler");
+  });
+
+  it("type-guard isCompilerError works", () => {
+    expect(isCompilerError(new CompilerError("X", "y"))).toBe(true);
+    expect(isCompilerError(new UIError("X", "y"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NetworkError
+// ---------------------------------------------------------------------------
+
+describe("NetworkError", () => {
+  it("severity is warning for RPC_TIMEOUT", () => {
+    const err = new NetworkError(ErrorCodes.RPC_TIMEOUT, "timed out");
+    expect(err.severity).toBe("warning");
+  });
+
+  it("severity is error for FETCH_FAILED", () => {
+    const err = new NetworkError(ErrorCodes.FETCH_FAILED, "network failure");
+    expect(err.severity).toBe("error");
+  });
+
+  it("type-guard isNetworkError works", () => {
+    expect(isNetworkError(new NetworkError("X", "y"))).toBe(true);
+    expect(isNetworkError(new CompilerError("X", "y"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ContractError
+// ---------------------------------------------------------------------------
+
+describe("ContractError", () => {
+  it("stores hostCode and reflects it in statusCode", () => {
+    const err = new ContractError(ErrorCodes.CONTRACT_HOST_ERROR, "trapped", 113);
+    expect(err.hostCode).toBe(113);
+    expect(err.meta.statusCode).toBe(113);
+    expect(err.domain).toBe("contract");
+  });
+
+  it("type-guard isContractError works", () => {
+    expect(isContractError(new ContractError("X", "y"))).toBe(true);
+    expect(isContractError(new AuthError("X", "y"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuthError
+// ---------------------------------------------------------------------------
+
+describe("AuthError", () => {
+  it("has domain = auth and severity = error", () => {
+    const err = new AuthError(ErrorCodes.SESSION_EXPIRED, "session expired");
+    expect(err.domain).toBe("auth");
+    expect(err.severity).toBe("error");
+  });
+
+  it("type-guard isAuthError works", () => {
+    expect(isAuthError(new AuthError("X", "y"))).toBe(true);
+    expect(isAuthError(new UIError("X", "y"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAppError generic guard
+// ---------------------------------------------------------------------------
+
+describe("isAppError", () => {
+  it("returns true for any AppError subclass", () => {
+    expect(isAppError(new AppError("X", "y", "ui"))).toBe(true);
+    expect(isAppError(new CompilerError("X", "y"))).toBe(true);
+    expect(isAppError(new NetworkError("X", "y"))).toBe(true);
+  });
+
+  it("returns false for plain Error and primitives", () => {
+    expect(isAppError(new Error("plain"))).toBe(false);
+    expect(isAppError("string error")).toBe(false);
+    expect(isAppError(null)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ErrorCodes — ensure constants are string literals
+// ---------------------------------------------------------------------------
+
+describe("ErrorCodes", () => {
+  it("all values are non-empty strings", () => {
+    for (const val of Object.values(ErrorCodes)) {
+      expect(typeof val).toBe("string");
+      expect(val.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("codes are SCREAMING_SNAKE_CASE", () => {
+    for (const val of Object.values(ErrorCodes)) {
+      expect(val).toMatch(/^[A-Z][A-Z0-9_]+$/);
+    }
+  });
+});

--- a/ide/src/lib/error/apiInterceptor.ts
+++ b/ide/src/lib/error/apiInterceptor.ts
@@ -1,0 +1,299 @@
+/**
+ * src/lib/error/apiInterceptor.ts
+ * ============================================================
+ * Global API Interceptor
+ *
+ * Drop-in replacement for `fetch` that:
+ *  1. Classifies HTTP and network failures into typed AppError subclasses
+ *  2. Fires a unified sonner toast for every failure
+ *  3. Logs categorised error objects to the console (never swallows them)
+ *  4. Re-throws so callers can add their own recovery logic
+ *
+ * Usage — replace bare `fetch(...)` calls:
+ *   import { apiFetch } from "@/lib/error/apiInterceptor";
+ *
+ *   const res = await apiFetch("/api/compile", { method: "POST", body: ... });
+ *   // On HTTP error → toast fires automatically, CompilerError / NetworkError thrown
+ *   // On success   → returns the raw Response (unchanged)
+ *
+ * Silent mode (no toast, error still thrown):
+ *   await apiFetch("/api/health", {}, { silent: true });
+ * ============================================================
+ */
+
+import { toast } from "sonner";
+import {
+  AppError,
+  CompilerError,
+  NetworkError,
+  ContractError,
+  AuthError,
+  UIError,
+  ErrorCodes,
+  type AppErrorMeta,
+} from "./AppError";
+
+// ---------------------------------------------------------------------------
+// Interceptor options
+// ---------------------------------------------------------------------------
+
+export interface InterceptorOptions {
+  /**
+   * When true, suppresses the automatic toast notification.
+   * The error is still thrown so callers can handle it.
+   */
+  silent?: boolean;
+  /**
+   * A short label describing what the request does,
+   * used to enrich the toast title (e.g. "contract compilation").
+   */
+  operation?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Route → domain mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps URL path prefixes to error domains so the interceptor can create
+ * the correct AppError subclass for each API route.
+ */
+const ROUTE_DOMAIN_MAP: Array<{ prefix: string; domain: "compiler" | "contract" | "auth" | "ui" | "network" }> = [
+  { prefix: "/api/compile",    domain: "compiler"  },
+  { prefix: "/api/clippy",     domain: "compiler"  },
+  { prefix: "/api/audit",      domain: "compiler"  },
+  { prefix: "/api/format",     domain: "compiler"  },
+  { prefix: "/api/bench",      domain: "compiler"  },
+  { prefix: "/api/fuzz",       domain: "compiler"  },
+  { prefix: "/api/run-test",   domain: "compiler"  },
+  { prefix: "/api/auth",       domain: "auth"      },
+  { prefix: "/api/projects",   domain: "ui"        },
+  { prefix: "/api/chat",       domain: "ui"        },
+  { prefix: "/api/error-help", domain: "ui"        },
+];
+
+function resolveDomain(url: string): "compiler" | "contract" | "auth" | "ui" | "network" {
+  try {
+    const pathname = new URL(url, "http://localhost").pathname;
+    for (const { prefix, domain } of ROUTE_DOMAIN_MAP) {
+      if (pathname.startsWith(prefix)) return domain;
+    }
+  } catch {
+    // URL parsing failed — treat as network error
+  }
+  return "network";
+}
+
+// ---------------------------------------------------------------------------
+// Error factory helpers
+// ---------------------------------------------------------------------------
+
+function buildErrorFromResponse(
+  res: Response,
+  body: string,
+  domain: ReturnType<typeof resolveDomain>,
+  operation: string,
+  meta: AppErrorMeta
+): AppError {
+  const status = res.status;
+
+  if (status === 401 || status === 403) {
+    return new AuthError(ErrorCodes.UNAUTHORIZED, `${operation} — access denied (HTTP ${status}).`, {
+      ...meta,
+      statusCode: status,
+      suggestions: [
+        "Re-authenticate and try again.",
+        "Check that your session has not expired.",
+      ],
+    });
+  }
+
+  if (domain === "compiler") {
+    const code =
+      status === 500 ? ErrorCodes.WASM_BUILD_FAILED : ErrorCodes.HTTP_ERROR;
+    return new CompilerError(
+      code,
+      `${operation} failed (HTTP ${status}).`,
+      body,
+      { ...meta, statusCode: status }
+    );
+  }
+
+  if (domain === "contract") {
+    return new ContractError(
+      ErrorCodes.CONTRACT_INVOCATION_FAILED,
+      `${operation} failed (HTTP ${status}).`,
+      undefined,
+      { ...meta, statusCode: status }
+    );
+  }
+
+  if (domain === "auth") {
+    return new AuthError(
+      ErrorCodes.UNAUTHORIZED,
+      `${operation} failed (HTTP ${status}).`,
+      { ...meta, statusCode: status }
+    );
+  }
+
+  if (domain === "ui") {
+    return new UIError(ErrorCodes.HTTP_ERROR, `${operation} failed (HTTP ${status}).`, {
+      ...meta,
+      statusCode: status,
+    });
+  }
+
+  // network / unknown
+  return new NetworkError(
+    ErrorCodes.HTTP_ERROR,
+    `${operation} failed (HTTP ${status}).`,
+    { ...meta, statusCode: status }
+  );
+}
+
+function buildNetworkError(err: unknown, operation: string): NetworkError {
+  const message =
+    err instanceof Error ? err.message : "Failed to reach the server.";
+
+  const isTimeout =
+    message.toLowerCase().includes("timeout") ||
+    (err instanceof DOMException && err.name === "TimeoutError");
+
+  return new NetworkError(
+    isTimeout ? ErrorCodes.RPC_TIMEOUT : ErrorCodes.FETCH_FAILED,
+    isTimeout
+      ? `${operation} timed out. The server did not respond in time.`
+      : `${operation} — network error: ${message}`,
+    {
+      cause: err,
+      suggestions: isTimeout
+        ? ["Try again in a moment.", "Check the RPC endpoint URL."]
+        : [
+            "Check your internet connection.",
+            "Verify the API server is running.",
+            "Try again in a moment.",
+          ],
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toast helper
+// ---------------------------------------------------------------------------
+
+function showErrorToast(error: AppError, operation: string): void {
+  const suggestions = error.meta.suggestions ?? [];
+  const description =
+    suggestions.length > 0
+      ? `${error.message}\n\n${suggestions.map((s) => `• ${s}`).join("\n")}`
+      : error.message;
+
+  const toastFn =
+    error.severity === "warning"
+      ? toast.warning
+      : error.severity === "info"
+        ? toast.info
+        : toast.error;
+
+  toastFn(error.title, {
+    description,
+    duration: error.severity === "error" ? 7000 : 5000,
+    id: `api-error-${error.code}`, // de-duplicate identical errors
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Console logger
+// ---------------------------------------------------------------------------
+
+function logError(error: AppError, url: string): void {
+  const prefix = `[${error.domain.toUpperCase()}][${error.code}]`;
+  console.error(`${prefix} ${error.message}`, {
+    url,
+    ...error.toJSON(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Core interceptor
+// ---------------------------------------------------------------------------
+
+/**
+ * Instrumented fetch wrapper.
+ *
+ * Returns the raw `Response` on success (2xx).
+ * On any failure, fires a toast (unless `silent`), logs to console, and
+ * throws a domain-specific `AppError` subclass.
+ */
+export async function apiFetch(
+  url: string,
+  init: RequestInit = {},
+  options: InterceptorOptions = {}
+): Promise<Response> {
+  const { silent = false, operation = "API request" } = options;
+  const domain = resolveDomain(url);
+
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (networkErr) {
+    const error = buildNetworkError(networkErr, operation);
+    logError(error, url);
+    if (!silent) showErrorToast(error, operation);
+    throw error;
+  }
+
+  if (!res.ok) {
+    // Read body for richer error info (best-effort)
+    let body = "";
+    try {
+      body = await res.clone().text();
+    } catch {
+      // Ignore body-read failures
+    }
+
+    const meta: AppErrorMeta = {
+      cause: new Error(`HTTP ${res.status} from ${url}`),
+      context: { url, status: res.status, body: body.slice(0, 500) },
+      statusCode: res.status,
+    };
+
+    const error = buildErrorFromResponse(res, body, domain, operation, meta);
+    logError(error, url);
+    if (!silent) showErrorToast(error, operation);
+    throw error;
+  }
+
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrappers for common patterns
+// ---------------------------------------------------------------------------
+
+/** POST JSON and return the parsed response body, with full error interception. */
+export async function apiPost<T = unknown>(
+  url: string,
+  body: unknown,
+  options: InterceptorOptions = {}
+): Promise<T> {
+  const res = await apiFetch(
+    url,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    options
+  );
+  return res.json() as Promise<T>;
+}
+
+/** GET and return the parsed response body, with full error interception. */
+export async function apiGet<T = unknown>(
+  url: string,
+  options: InterceptorOptions = {}
+): Promise<T> {
+  const res = await apiFetch(url, { method: "GET" }, options);
+  return res.json() as Promise<T>;
+}

--- a/ide/src/lib/error/index.ts
+++ b/ide/src/lib/error/index.ts
@@ -1,0 +1,18 @@
+/**
+ * src/lib/error/index.ts
+ * ============================================================
+ * Public barrel for the error handling framework.
+ *
+ * Import everything you need from this single entry-point:
+ *
+ *   import {
+ *     AppError, CompilerError, NetworkError, ContractError, AuthError, UIError,
+ *     ErrorCodes,
+ *     isAppError, isCompilerError, isNetworkError,
+ *     apiFetch, apiPost, apiGet,
+ *   } from "@/lib/error";
+ * ============================================================
+ */
+
+export * from "./AppError";
+export * from "./apiInterceptor";

--- a/ide/tsconfig.json
+++ b/ide/tsconfig.json
@@ -19,6 +19,7 @@
     "noEmit": true,
     "incremental": true,
     "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
## Summary

Closes #649  — Standardized Error Handling Framework

## What's in this PR

### `ide/src/lib/error/AppError.ts`
Domain-specific error subclasses with typed codes, severity levels, structured metadata, and JSON serialisation:
- `UIError` — form validation, unsupported browser features
- `CompilerError` — cargo build, clippy, WASM upload failures (stores raw compiler output)
- `NetworkError` — RPC timeouts, fetch failures (auto-sets `warning` severity for timeouts)
- `ContractError` — host-function errors, simulation/invocation failures (stores Soroban host code)
- `AuthError` — wallet connection, expired sessions
- `ErrorCodes` constants (no magic strings at call-sites)
- `isAppError` / domain-specific type-guards

### `ide/src/lib/error/apiInterceptor.ts`
Global `fetch` wrapper (`apiFetch`, `apiPost`, `apiGet`) that:
- Classifies HTTP & network failures into the correct `AppError` subclass based on the route
- Fires categorised sonner toasts automatically (`toast.error` / `toast.warning`)
- Logs structured error objects to the console with a `[DOMAIN][CODE]` prefix
- Re-throws so call-sites can still add recovery logic

### `ide/src/lib/error/index.ts`
Barrel export — single import path for everything.

### `ide/src/lib/error/__tests__/AppError.test.ts`
20 Vitest unit tests — all passing ✅

## Verified Terminal Output

