### PR TITLE
feat: network-config-store

### DIFF
--- a/ide/src/store/__tests__/useNetworkStore.test.ts
+++ b/ide/src/store/__tests__/useNetworkStore.test.ts
@@ -1,0 +1,393 @@
+/**
+ * src/store/__tests__/useNetworkStore.test.ts
+ * ──────────────────────────────────────────────────────────────
+ * Unit tests for useNetworkStore (#647)
+ * ──────────────────────────────────────────────────────────────
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useNetworkStore } from "../useNetworkStore";
+import { NETWORK_CONFIG } from "@/lib/networkConfig";
+
+// Reset store state before every test
+beforeEach(() => {
+  useNetworkStore.getState().reset();
+});
+
+// ─────────────────────────────────────────────────────────────
+// Initial defaults
+// ─────────────────────────────────────────────────────────────
+
+describe("initial state", () => {
+  it("defaults to testnet preset", () => {
+    const s = useNetworkStore.getState();
+    expect(s.activeNetwork).toBe("testnet");
+    expect(s.activeProfileId).toBeNull();
+  });
+
+  it("resolves testnet RPC URL by default", () => {
+    const s = useNetworkStore.getState();
+    expect(s.resolvedRpcUrl()).toBe(NETWORK_CONFIG.testnet.horizon);
+  });
+
+  it("resolves testnet passphrase by default", () => {
+    const s = useNetworkStore.getState();
+    expect(s.resolvedPassphrase()).toBe(NETWORK_CONFIG.testnet.passphrase);
+  });
+
+  it("resolves testnet horizon URL by default", () => {
+    const s = useNetworkStore.getState();
+    expect(s.resolvedHorizonUrl()).toBe(NETWORK_CONFIG.testnet.horizonUrl);
+  });
+
+  it("starts with empty profiles list", () => {
+    expect(useNetworkStore.getState().profiles).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Preset selection
+// ─────────────────────────────────────────────────────────────
+
+describe("selectPreset", () => {
+  it("switches to mainnet and resolves correct URLs", () => {
+    useNetworkStore.getState().selectPreset("mainnet");
+    const s = useNetworkStore.getState();
+    expect(s.activeNetwork).toBe("mainnet");
+    expect(s.resolvedPassphrase()).toBe(NETWORK_CONFIG.mainnet.passphrase);
+    expect(s.resolvedHorizonUrl()).toBe(NETWORK_CONFIG.mainnet.horizonUrl);
+  });
+
+  it("switches to futurenet", () => {
+    useNetworkStore.getState().selectPreset("futurenet");
+    expect(useNetworkStore.getState().activeNetwork).toBe("futurenet");
+  });
+
+  it("switches to local", () => {
+    useNetworkStore.getState().selectPreset("local");
+    expect(useNetworkStore.getState().resolvedRpcUrl()).toContain("localhost");
+  });
+
+  it("clears activeProfileId when switching to a preset", () => {
+    // Add and select a profile first
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "My Net",
+      rpcUrl: "https://custom.example.com",
+      passphrase: "Custom Net Passphrase ; 2024",
+    });
+    useNetworkStore.getState().selectProfile(id!);
+    expect(useNetworkStore.getState().activeProfileId).toBe(id);
+
+    // Switch to a preset — profileId must clear
+    useNetworkStore.getState().selectPreset("testnet");
+    expect(useNetworkStore.getState().activeProfileId).toBeNull();
+  });
+
+  it("sets lastChangedAt", () => {
+    useNetworkStore.getState().selectPreset("mainnet");
+    expect(useNetworkStore.getState().lastChangedAt).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Custom RPC URL
+// ─────────────────────────────────────────────────────────────
+
+describe("setCustomRpcUrl", () => {
+  it("accepts a valid https URL", () => {
+    const result = useNetworkStore.getState().setCustomRpcUrl("https://rpc.example.com");
+    expect(result.valid).toBe(true);
+    expect(useNetworkStore.getState().customRpcUrl).toBe("https://rpc.example.com");
+  });
+
+  it("accepts a valid http URL (e.g. localhost)", () => {
+    const result = useNetworkStore.getState().setCustomRpcUrl("http://localhost:8000");
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects an empty string", () => {
+    const result = useNetworkStore.getState().setCustomRpcUrl("");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it("rejects a non-URL string", () => {
+    const result = useNetworkStore.getState().setCustomRpcUrl("not-a-url");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects ftp:// protocol", () => {
+    const result = useNetworkStore.getState().setCustomRpcUrl("ftp://example.com");
+    expect(result.valid).toBe(false);
+  });
+
+  it("sets activeNetwork to 'custom' on success", () => {
+    useNetworkStore.getState().setCustomRpcUrl("https://rpc.example.com");
+    expect(useNetworkStore.getState().activeNetwork).toBe("custom");
+  });
+
+  it("sets validationError on failure", () => {
+    useNetworkStore.getState().setCustomRpcUrl("bad-url");
+    expect(useNetworkStore.getState().validationError).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Custom passphrase
+// ─────────────────────────────────────────────────────────────
+
+describe("setCustomPassphrase", () => {
+  it("accepts a valid passphrase", () => {
+    const result = useNetworkStore.getState().setCustomPassphrase("My Stellar Net ; 2024");
+    expect(result.valid).toBe(true);
+    expect(useNetworkStore.getState().customPassphrase).toBe("My Stellar Net ; 2024");
+  });
+
+  it("rejects empty passphrase", () => {
+    const result = useNetworkStore.getState().setCustomPassphrase("");
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects passphrase shorter than 8 chars", () => {
+    const result = useNetworkStore.getState().setCustomPassphrase("short");
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Custom headers
+// ─────────────────────────────────────────────────────────────
+
+describe("custom headers", () => {
+  it("merges new headers into existing ones", () => {
+    useNetworkStore.getState().setCustomHeaders({ "X-Api-Key": "abc" });
+    useNetworkStore.getState().setCustomHeaders({ "X-Tenant": "xyz" });
+    const headers = useNetworkStore.getState().customHeaders;
+    expect(headers["X-Api-Key"]).toBe("abc");
+    expect(headers["X-Tenant"]).toBe("xyz");
+  });
+
+  it("removes a single header by key", () => {
+    useNetworkStore.getState().setCustomHeaders({ "X-Remove-Me": "yes" });
+    useNetworkStore.getState().removeCustomHeader("X-Remove-Me");
+    expect(useNetworkStore.getState().customHeaders["X-Remove-Me"]).toBeUndefined();
+  });
+
+  it("clears all headers", () => {
+    useNetworkStore.getState().setCustomHeaders({ A: "1", B: "2" });
+    useNetworkStore.getState().clearCustomHeaders();
+    expect(Object.keys(useNetworkStore.getState().customHeaders)).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Profile CRUD
+// ─────────────────────────────────────────────────────────────
+
+describe("addProfile", () => {
+  it("adds a valid profile and returns its ID", () => {
+    const { id, error } = useNetworkStore.getState().addProfile({
+      label: "Staging",
+      rpcUrl: "https://staging-rpc.example.com",
+      passphrase: "Staging Network ; 2024",
+    });
+    expect(error).toBeUndefined();
+    expect(id).toBeTruthy();
+    expect(useNetworkStore.getState().profiles).toHaveLength(1);
+  });
+
+  it("rejects a profile with an invalid RPC URL", () => {
+    const { id, error } = useNetworkStore.getState().addProfile({
+      label: "Bad",
+      rpcUrl: "not-a-url",
+      passphrase: "Valid Passphrase ; 2024",
+    });
+    expect(id).toBeNull();
+    expect(error).toBeTruthy();
+  });
+
+  it("rejects a profile with an empty passphrase", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "Empty Pass",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "",
+    });
+    expect(id).toBeNull();
+  });
+
+  it("each profile gets a unique id", () => {
+    const { id: id1 } = useNetworkStore.getState().addProfile({
+      label: "Net 1",
+      rpcUrl: "https://rpc1.example.com",
+      passphrase: "Network One ; 2024",
+    });
+    const { id: id2 } = useNetworkStore.getState().addProfile({
+      label: "Net 2",
+      rpcUrl: "https://rpc2.example.com",
+      passphrase: "Network Two ; 2024",
+    });
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe("selectProfile", () => {
+  it("activates a profile and populates overrides", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "My Custom",
+      rpcUrl: "https://my-rpc.example.com",
+      passphrase: "My Custom Network ; 2024",
+    });
+    useNetworkStore.getState().selectProfile(id!);
+    const s = useNetworkStore.getState();
+    expect(s.activeNetwork).toBe("custom");
+    expect(s.activeProfileId).toBe(id);
+    expect(s.resolvedRpcUrl()).toBe("https://my-rpc.example.com");
+    expect(s.resolvedPassphrase()).toBe("My Custom Network ; 2024");
+  });
+
+  it("sets validationError when profile ID is unknown", () => {
+    useNetworkStore.getState().selectProfile("non-existent-id");
+    expect(useNetworkStore.getState().validationError).toBeTruthy();
+  });
+});
+
+describe("updateProfile", () => {
+  it("updates profile fields", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "Old Label",
+      rpcUrl: "https://old.example.com",
+      passphrase: "Old Passphrase ; 2024",
+    });
+    const result = useNetworkStore.getState().updateProfile(id!, {
+      label: "New Label",
+      rpcUrl: "https://new.example.com",
+    });
+    expect(result.valid).toBe(true);
+    const updated = useNetworkStore.getState().profiles.find((p) => p.id === id);
+    expect(updated?.label).toBe("New Label");
+    expect(updated?.rpcUrl).toBe("https://new.example.com");
+  });
+
+  it("rejects invalid URL on update", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "Net",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "Passphrase ; 2024",
+    });
+    const result = useNetworkStore.getState().updateProfile(id!, { rpcUrl: "bad" });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("removeProfile", () => {
+  it("removes a profile by ID", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "To Delete",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "Passphrase ; 2024",
+    });
+    useNetworkStore.getState().removeProfile(id!);
+    expect(useNetworkStore.getState().profiles).toHaveLength(0);
+  });
+
+  it("falls back to testnet if the active profile is removed", () => {
+    const { id } = useNetworkStore.getState().addProfile({
+      label: "Active",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "Active Passphrase ; 2024",
+    });
+    useNetworkStore.getState().selectProfile(id!);
+    useNetworkStore.getState().removeProfile(id!);
+    expect(useNetworkStore.getState().activeNetwork).toBe("testnet");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Export / Import profiles
+// ─────────────────────────────────────────────────────────────
+
+describe("exportProfiles / importProfiles", () => {
+  it("exports profiles as valid JSON", () => {
+    useNetworkStore.getState().addProfile({
+      label: "Export Me",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "Export Passphrase ; 2024",
+    });
+    const json = useNetworkStore.getState().exportProfiles();
+    const parsed = JSON.parse(json);
+    expect(parsed.profiles).toHaveLength(1);
+    expect(parsed.version).toBe(1);
+  });
+
+  it("imports profiles from valid JSON", () => {
+    const json = JSON.stringify({
+      version: 1,
+      profiles: [
+        {
+          label: "Imported",
+          rpcUrl: "https://imported.example.com",
+          passphrase: "Imported Network ; 2024",
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    const { imported, error } = useNetworkStore.getState().importProfiles(json);
+    expect(error).toBeUndefined();
+    expect(imported).toBe(1);
+    expect(useNetworkStore.getState().profiles).toHaveLength(1);
+  });
+
+  it("skips duplicate profiles on import", () => {
+    useNetworkStore.getState().addProfile({
+      label: "Existing",
+      rpcUrl: "https://dup.example.com",
+      passphrase: "Existing Passphrase ; 2024",
+    });
+    const json = JSON.stringify({
+      profiles: [{ label: "Existing", rpcUrl: "https://dup.example.com", passphrase: "X" }],
+    });
+    const { imported } = useNetworkStore.getState().importProfiles(json);
+    expect(imported).toBe(0);
+    expect(useNetworkStore.getState().profiles).toHaveLength(1);
+  });
+
+  it("returns error on invalid JSON", () => {
+    const { imported, error } = useNetworkStore.getState().importProfiles("not json");
+    expect(imported).toBe(0);
+    expect(error).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// resolvedConfig
+// ─────────────────────────────────────────────────────────────
+
+describe("resolvedConfig", () => {
+  it("returns a full config object for the active preset", () => {
+    useNetworkStore.getState().selectPreset("mainnet");
+    const cfg = useNetworkStore.getState().resolvedConfig();
+    expect(cfg.label).toBe("Mainnet");
+    expect(cfg.passphrase).toBe(NETWORK_CONFIG.mainnet.passphrase);
+    expect(cfg.rpcUrl).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// reset
+// ─────────────────────────────────────────────────────────────
+
+describe("reset", () => {
+  it("restores factory defaults", () => {
+    useNetworkStore.getState().selectPreset("mainnet");
+    useNetworkStore.getState().addProfile({
+      label: "P",
+      rpcUrl: "https://rpc.example.com",
+      passphrase: "Passphrase ; 2024",
+    });
+    useNetworkStore.getState().reset();
+    const s = useNetworkStore.getState();
+    expect(s.activeNetwork).toBe("testnet");
+    expect(s.profiles).toHaveLength(0);
+    expect(s.customPassphrase).toBe("");
+  });
+});

--- a/ide/src/store/useNetworkStore.ts
+++ b/ide/src/store/useNetworkStore.ts
@@ -1,0 +1,588 @@
+/**
+ * src/store/useNetworkStore.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Centralized Network Configuration Store  — Issue #647
+ *
+ * Single source of truth for:
+ *  • Active network selection (testnet | futurenet | mainnet | local | custom)
+ *  • RPC endpoint URL (preset or custom, with validation)
+ *  • Network passphrase
+ *  • Horizon URL
+ *  • Custom RPC headers
+ *  • Named custom network profiles (CRUD)
+ *
+ * All state is persisted to localStorage under the key
+ * "stellar-suite-network-store" so user preferences survive page reloads.
+ *
+ * Design notes
+ * ────────────
+ * • Extends `NetworkKey` with a "custom" literal so components can distinguish
+ *   between a built-in preset and a fully user-defined endpoint.
+ * • `resolvedRpcUrl` / `resolvedPassphrase` are derived getters that merge
+ *   the active preset with any user override — no component needs to do this
+ *   logic themselves.
+ * • Validation is run on every URL/passphrase setter so invalid values are
+ *   rejected immediately and an `error` field is set for UI feedback.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+"use client";
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import {
+  NETWORK_CONFIG,
+  DEFAULT_CUSTOM_RPC,
+  type NetworkKey,
+  type NetworkConfig,
+  type CustomHeaders,
+} from "@/lib/networkConfig";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** All built-in presets + a "custom" sentinel */
+export type ExtendedNetworkKey = NetworkKey | "custom";
+
+/**
+ * A user-saved custom network profile.
+ * Multiple profiles can be stored; one can be made active.
+ */
+export interface CustomNetworkProfile {
+  /** UUID-style identifier */
+  id: string;
+  /** Human-readable name shown in the selector */
+  label: string;
+  /** Soroban RPC URL */
+  rpcUrl: string;
+  /** Network passphrase for transaction signing */
+  passphrase: string;
+  /** Optional Horizon REST API URL */
+  horizonUrl?: string;
+  /** Optional per-request HTTP headers */
+  headers?: CustomHeaders;
+  /** ISO timestamp when this profile was last modified */
+  updatedAt: string;
+}
+
+/** Validation result returned from URL/passphrase setters */
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface NetworkStoreState {
+  // ── Active selection ──────────────────────────────────────────────────────
+
+  /** Currently active network key (built-in preset or "custom") */
+  activeNetwork: ExtendedNetworkKey;
+
+  /**
+   * When `activeNetwork === "custom"`, the ID of the selected
+   * `CustomNetworkProfile` — or `null` for an inline override.
+   */
+  activeProfileId: string | null;
+
+  // ── Overrides (apply on top of any preset) ────────────────────────────────
+
+  /** User-supplied RPC URL (overrides the preset's default when set) */
+  customRpcUrl: string;
+  /** User-supplied network passphrase override */
+  customPassphrase: string;
+  /** User-supplied Horizon URL override */
+  customHorizonUrl: string;
+  /** Per-request HTTP headers sent to the RPC endpoint */
+  customHeaders: CustomHeaders;
+
+  // ── Saved profiles ────────────────────────────────────────────────────────
+
+  /** Ordered list of user-saved custom network profiles */
+  profiles: CustomNetworkProfile[];
+
+  // ── UI state ─────────────────────────────────────────────────────────────
+
+  /** Last validation error, cleared when state becomes valid */
+  validationError: string | null;
+  /** ISO timestamp of last successful network selection change */
+  lastChangedAt: string | null;
+
+  // ── Derived / computed (getters) ──────────────────────────────────────────
+
+  /**
+   * The RPC URL that should be used for all requests.
+   * Priority: customRpcUrl override → activeProfile.rpcUrl → preset default
+   */
+  resolvedRpcUrl: () => string;
+
+  /**
+   * The network passphrase for transaction signing.
+   * Priority: customPassphrase → activeProfile.passphrase → preset default
+   */
+  resolvedPassphrase: () => string;
+
+  /**
+   * The Horizon REST API URL.
+   * Priority: customHorizonUrl → activeProfile.horizonUrl → preset default
+   */
+  resolvedHorizonUrl: () => string;
+
+  /**
+   * The merged HTTP headers (profile headers + customHeaders overrides).
+   */
+  resolvedHeaders: () => CustomHeaders;
+
+  /**
+   * Snapshot of the fully-resolved NetworkConfig-compatible object.
+   * Useful for passing to RpcService / eventSubscriber without picking fields.
+   */
+  resolvedConfig: () => NetworkConfig & { rpcUrl: string };
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  /**
+   * Switch to a built-in network preset.
+   * Clears all overrides and activeProfileId so the preset defaults apply.
+   */
+  selectPreset: (network: NetworkKey) => void;
+
+  /**
+   * Switch to a saved custom profile by its ID.
+   * Sets activeNetwork to "custom" and populates overrides from the profile.
+   */
+  selectProfile: (profileId: string) => void;
+
+  /**
+   * Directly set the RPC URL (inline override, no profile required).
+   * Returns a ValidationResult; invalid URLs are rejected.
+   */
+  setCustomRpcUrl: (url: string) => ValidationResult;
+
+  /**
+   * Override the network passphrase.
+   * Returns a ValidationResult; empty passphrases are rejected.
+   */
+  setCustomPassphrase: (passphrase: string) => ValidationResult;
+
+  /** Override the Horizon URL. */
+  setCustomHorizonUrl: (url: string) => ValidationResult;
+
+  /** Merge additional headers into customHeaders (existing keys are overwritten). */
+  setCustomHeaders: (headers: CustomHeaders) => void;
+
+  /** Remove a single header key. */
+  removeCustomHeader: (key: string) => void;
+
+  /** Clear all header overrides. */
+  clearCustomHeaders: () => void;
+
+  // ── Profile CRUD ──────────────────────────────────────────────────────────
+
+  /**
+   * Save a new custom network profile.
+   * Returns the generated profile ID on success or null if validation failed.
+   */
+  addProfile: (
+    input: Omit<CustomNetworkProfile, "id" | "updatedAt">
+  ) => { id: string | null; error?: string };
+
+  /** Update fields on an existing profile by ID. */
+  updateProfile: (
+    id: string,
+    patch: Partial<Omit<CustomNetworkProfile, "id" | "updatedAt">>
+  ) => ValidationResult;
+
+  /** Delete a profile. If it was active, falls back to "testnet". */
+  removeProfile: (id: string) => void;
+
+  /** Export all profiles as a JSON string for sharing/backup. */
+  exportProfiles: () => string;
+
+  /**
+   * Import profiles from a JSON string.
+   * Existing profiles with the same label+rpcUrl pair are skipped (dedup).
+   */
+  importProfiles: (json: string) => { imported: number; error?: string };
+
+  /** Reset everything back to factory defaults. */
+  reset: () => void;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+/** Basic URL validation — must be http:// or https:// */
+function validateUrl(url: string): ValidationResult {
+  const trimmed = url.trim();
+  if (!trimmed) return { valid: false, error: "URL must not be empty." };
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return { valid: false, error: "URL must use http or https protocol." };
+    }
+    return { valid: true };
+  } catch {
+    return { valid: false, error: `"${trimmed}" is not a valid URL.` };
+  }
+}
+
+function validatePassphrase(p: string): ValidationResult {
+  const trimmed = p.trim();
+  if (!trimmed) return { valid: false, error: "Passphrase must not be empty." };
+  if (trimmed.length < 8)
+    return { valid: false, error: "Passphrase must be at least 8 characters." };
+  return { valid: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default state values
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULTS = {
+  activeNetwork: "testnet" as ExtendedNetworkKey,
+  activeProfileId: null as string | null,
+  customRpcUrl: NETWORK_CONFIG.testnet.horizon,
+  customPassphrase: "",
+  customHorizonUrl: "",
+  customHeaders: {} as CustomHeaders,
+  profiles: [] as CustomNetworkProfile[],
+  validationError: null as string | null,
+  lastChangedAt: null as string | null,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Store
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const useNetworkStore = create<NetworkStoreState>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULTS,
+
+      // ── Derived getters ────────────────────────────────────────────────────
+
+      resolvedRpcUrl: () => {
+        const s = get();
+        if (s.customRpcUrl && s.customRpcUrl !== NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.horizon) {
+          return s.customRpcUrl;
+        }
+        if (s.activeProfileId) {
+          const profile = s.profiles.find((p) => p.id === s.activeProfileId);
+          if (profile) return profile.rpcUrl;
+        }
+        if (s.activeNetwork === "custom") return s.customRpcUrl || DEFAULT_CUSTOM_RPC;
+        return NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.horizon ?? DEFAULT_CUSTOM_RPC;
+      },
+
+      resolvedPassphrase: () => {
+        const s = get();
+        if (s.customPassphrase) return s.customPassphrase;
+        if (s.activeProfileId) {
+          const profile = s.profiles.find((p) => p.id === s.activeProfileId);
+          if (profile) return profile.passphrase;
+        }
+        if (s.activeNetwork === "custom") return s.customPassphrase;
+        return NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.passphrase ?? "";
+      },
+
+      resolvedHorizonUrl: () => {
+        const s = get();
+        if (s.customHorizonUrl) return s.customHorizonUrl;
+        if (s.activeProfileId) {
+          const profile = s.profiles.find((p) => p.id === s.activeProfileId);
+          if (profile?.horizonUrl) return profile.horizonUrl;
+        }
+        if (s.activeNetwork === "custom") return s.customHorizonUrl;
+        return NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.horizonUrl ?? "";
+      },
+
+      resolvedHeaders: () => {
+        const s = get();
+        const profileHeaders =
+          s.activeProfileId
+            ? s.profiles.find((p) => p.id === s.activeProfileId)?.headers ?? {}
+            : {};
+        return { ...profileHeaders, ...s.customHeaders };
+      },
+
+      resolvedConfig: () => {
+        const s = get();
+        return {
+          label: s.activeNetwork === "custom"
+            ? (s.profiles.find((p) => p.id === s.activeProfileId)?.label ?? "Custom")
+            : NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.label ?? "Custom",
+          horizon: s.resolvedRpcUrl(),
+          rpcUrl: s.resolvedRpcUrl(),
+          horizonUrl: s.resolvedHorizonUrl(),
+          passphrase: s.resolvedPassphrase(),
+          secondaryRpcUrls: s.activeNetwork !== "custom"
+            ? (NETWORK_CONFIG[s.activeNetwork as NetworkKey]?.secondaryRpcUrls ?? [])
+            : [],
+        };
+      },
+
+      // ── Actions ────────────────────────────────────────────────────────────
+
+      selectPreset: (network) => {
+        const config = NETWORK_CONFIG[network];
+        set({
+          activeNetwork: network,
+          activeProfileId: null,
+          customRpcUrl: config.horizon,
+          customPassphrase: "",
+          customHorizonUrl: "",
+          validationError: null,
+          lastChangedAt: now(),
+        });
+      },
+
+      selectProfile: (profileId) => {
+        const { profiles } = get();
+        const profile = profiles.find((p) => p.id === profileId);
+        if (!profile) {
+          set({ validationError: `Profile "${profileId}" not found.` });
+          return;
+        }
+        set({
+          activeNetwork: "custom",
+          activeProfileId: profileId,
+          customRpcUrl: profile.rpcUrl,
+          customPassphrase: profile.passphrase,
+          customHorizonUrl: profile.horizonUrl ?? "",
+          customHeaders: profile.headers ?? {},
+          validationError: null,
+          lastChangedAt: now(),
+        });
+      },
+
+      setCustomRpcUrl: (url) => {
+        const result = validateUrl(url);
+        if (!result.valid) {
+          set({ validationError: result.error ?? null });
+          return result;
+        }
+        set({
+          customRpcUrl: url.trim(),
+          activeNetwork: "custom",
+          activeProfileId: null,
+          validationError: null,
+          lastChangedAt: now(),
+        });
+        return result;
+      },
+
+      setCustomPassphrase: (passphrase) => {
+        const result = validatePassphrase(passphrase);
+        if (!result.valid) {
+          set({ validationError: result.error ?? null });
+          return result;
+        }
+        set({
+          customPassphrase: passphrase.trim(),
+          activeNetwork: "custom",
+          activeProfileId: null,
+          validationError: null,
+          lastChangedAt: now(),
+        });
+        return result;
+      },
+
+      setCustomHorizonUrl: (url) => {
+        if (url === "") {
+          // Clearing is allowed
+          set({ customHorizonUrl: "", validationError: null });
+          return { valid: true };
+        }
+        const result = validateUrl(url);
+        if (!result.valid) {
+          set({ validationError: result.error ?? null });
+          return result;
+        }
+        set({ customHorizonUrl: url.trim(), validationError: null });
+        return result;
+      },
+
+      setCustomHeaders: (headers) =>
+        set((s) => ({
+          customHeaders: { ...s.customHeaders, ...headers },
+        })),
+
+      removeCustomHeader: (key) =>
+        set((s) => {
+          const next = { ...s.customHeaders };
+          delete next[key];
+          return { customHeaders: next };
+        }),
+
+      clearCustomHeaders: () => set({ customHeaders: {} }),
+
+      // ── Profile CRUD ───────────────────────────────────────────────────────
+
+      addProfile: (input) => {
+        const urlCheck = validateUrl(input.rpcUrl);
+        if (!urlCheck.valid) return { id: null, error: urlCheck.error };
+
+        const passphraseCheck = validatePassphrase(input.passphrase);
+        if (!passphraseCheck.valid) return { id: null, error: passphraseCheck.error };
+
+        if (input.horizonUrl) {
+          const horizonCheck = validateUrl(input.horizonUrl);
+          if (!horizonCheck.valid) return { id: null, error: horizonCheck.error };
+        }
+
+        const id = generateId();
+        const profile: CustomNetworkProfile = {
+          ...input,
+          id,
+          updatedAt: now(),
+        };
+        set((s) => ({ profiles: [...s.profiles, profile] }));
+        return { id };
+      },
+
+      updateProfile: (id, patch) => {
+        const { profiles } = get();
+        const existing = profiles.find((p) => p.id === id);
+        if (!existing) return { valid: false, error: `Profile "${id}" not found.` };
+
+        if (patch.rpcUrl !== undefined) {
+          const check = validateUrl(patch.rpcUrl);
+          if (!check.valid) return check;
+        }
+        if (patch.passphrase !== undefined) {
+          const check = validatePassphrase(patch.passphrase);
+          if (!check.valid) return check;
+        }
+        if (patch.horizonUrl !== undefined && patch.horizonUrl !== "") {
+          const check = validateUrl(patch.horizonUrl);
+          if (!check.valid) return check;
+        }
+
+        set((s) => ({
+          profiles: s.profiles.map((p) =>
+            p.id === id ? { ...p, ...patch, updatedAt: now() } : p
+          ),
+        }));
+
+        // If this profile is currently active, sync the overrides
+        if (get().activeProfileId === id) {
+          get().selectProfile(id);
+        }
+        return { valid: true };
+      },
+
+      removeProfile: (id) => {
+        const { activeProfileId } = get();
+        set((s) => ({ profiles: s.profiles.filter((p) => p.id !== id) }));
+        if (activeProfileId === id) {
+          // Fall back to testnet
+          get().selectPreset("testnet");
+        }
+      },
+
+      exportProfiles: () => {
+        const { profiles } = get();
+        return JSON.stringify({ version: 1, profiles, exportedAt: now() }, null, 2);
+      },
+
+      importProfiles: (json) => {
+        try {
+          const parsed = JSON.parse(json) as {
+            profiles?: Omit<CustomNetworkProfile, "id">[];
+          };
+          const incoming = Array.isArray(parsed.profiles) ? parsed.profiles : [];
+          const { profiles } = get();
+
+          let imported = 0;
+          const newProfiles: CustomNetworkProfile[] = [];
+
+          for (const p of incoming) {
+            // Skip exact URL + label duplicates
+            const isDuplicate = profiles.some(
+              (e) => e.rpcUrl === p.rpcUrl && e.label === p.label
+            );
+            if (!isDuplicate) {
+              const urlCheck = validateUrl(p.rpcUrl);
+              if (!urlCheck.valid) continue;
+              newProfiles.push({ ...p, id: generateId(), updatedAt: now() });
+              imported++;
+            }
+          }
+
+          set((s) => ({ profiles: [...s.profiles, ...newProfiles] }));
+          return { imported };
+        } catch (e) {
+          return {
+            imported: 0,
+            error: e instanceof Error ? e.message : "Invalid JSON",
+          };
+        }
+      },
+
+      reset: () =>
+        set({
+          ...DEFAULTS,
+          lastChangedAt: now(),
+        }),
+    }),
+    {
+      name: "stellar-suite-network-store",
+      storage: createJSONStorage(() => localStorage),
+      // Only persist user-editable fields; computed getters are not serialisable
+      partialize: (s) => ({
+        activeNetwork: s.activeNetwork,
+        activeProfileId: s.activeProfileId,
+        customRpcUrl: s.customRpcUrl,
+        customPassphrase: s.customPassphrase,
+        customHorizonUrl: s.customHorizonUrl,
+        customHeaders: s.customHeaders,
+        profiles: s.profiles,
+        lastChangedAt: s.lastChangedAt,
+      }),
+    }
+  )
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Convenience selector hooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Returns the fully-resolved RPC URL for use in fetch / eventSubscriber calls. */
+export const useResolvedRpcUrl = () =>
+  useNetworkStore((s) => s.resolvedRpcUrl());
+
+/** Returns the fully-resolved network passphrase for transaction signing. */
+export const useResolvedPassphrase = () =>
+  useNetworkStore((s) => s.resolvedPassphrase());
+
+/** Returns the currently active network key. */
+export const useActiveNetwork = () =>
+  useNetworkStore((s) => s.activeNetwork);
+
+/** Returns all saved custom network profiles. */
+export const useNetworkProfiles = () =>
+  useNetworkStore((s) => s.profiles);
+
+/** Returns the current validation error (if any). */
+export const useNetworkValidationError = () =>
+  useNetworkStore((s) => s.validationError);
+
+/** Returns the fully-resolved network config snapshot. */
+export const useResolvedNetworkConfig = () =>
+  useNetworkStore((s) => s.resolvedConfig());


### PR DESCRIPTION
## Summary
Closes #647 — Centralized Network Configuration Store

## Deliverable
`ide/src/store/useNetworkStore.ts`

## What's in this PR

**Single source of truth for all network-aware components:**
- `ExtendedNetworkKey`: `testnet | futurenet | mainnet | local | custom`
- `selectPreset(network)` — switches built-in presets, auto-populates RPC URL, passphrase, horizon URL
- `setCustomRpcUrl(url)` — validated (http/https only, rejects empty/invalid)
- `setCustomPassphrase(p)` — validated (min 8 chars)
- `setCustomHorizonUrl(url)` — validated override
- Header management: `setCustomHeaders` / `removeCustomHeader` / `clearCustomHeaders`

**Named custom network profiles (CRUD):**
- `addProfile` / `updateProfile` / `removeProfile` / `selectProfile`
- Falls back to testnet automatically if the active profile is deleted
- `exportProfiles()` / `importProfiles()` — JSON-based sharing with deduplication

**Derived getters (no component-side logic needed):**
- `resolvedRpcUrl()`, `resolvedPassphrase()`, `resolvedHorizonUrl()`, `resolvedHeaders()`, `resolvedConfig()`

**Persistence:** `localStorage` via `zustand/middleware persist`

**Convenience hooks:** `useResolvedRpcUrl`, `useResolvedPassphrase`, `useActiveNetwork`, `useNetworkProfiles`, `useResolvedNetworkConfig`

## Verified Terminal Output
