### PR TITLE
refactor: wallet-adapter-pattern

### DIFF
--- a/ide/src/lib/wallet/AlbedoAdapter.ts
+++ b/ide/src/lib/wallet/AlbedoAdapter.ts
@@ -1,0 +1,110 @@
+/**
+ * src/lib/wallet/AlbedoAdapter.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WalletAdapter implementation for Albedo (web-based popup wallet).
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import {
+  BaseWalletAdapter,
+  WalletAdapterRegistry,
+  WalletAdapterError,
+  type ConnectResult,
+  type SignOptions,
+  type WalletAdapterInfo,
+} from "./BaseAdapter";
+import albedo from "@albedo-link/intent";
+
+// ── Metadata ─────────────────────────────────────────────────────────────────
+
+const ALBEDO_INFO: WalletAdapterInfo = {
+  id: "albedo",
+  name: "Albedo",
+  description: "Web-based Stellar wallet — no extension required.",
+  url: "https://albedo.link",
+  capabilities: {
+    canSignTransaction: true,
+    canSignAuthEntry: false,
+    canCheckConnection: false, // Albedo has no persistent session without user interaction
+    isExtension: false,
+  },
+};
+
+// ── Adapter ───────────────────────────────────────────────────────────────────
+
+export class AlbedoAdapter extends BaseWalletAdapter {
+  readonly info: WalletAdapterInfo = ALBEDO_INFO;
+
+  /** Albedo is always "available" — it's a web popup, no install required. */
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async connect(): Promise<ConnectResult> {
+    try {
+      const response = await albedo.publicKey({});
+      if (!response?.pubkey) {
+        throw new WalletAdapterError(
+          "albedo",
+          "CONNECTION_FAILED",
+          "Albedo did not return a public key."
+        );
+      }
+      return { publicKey: response.pubkey };
+    } catch (err) {
+      if (err instanceof WalletAdapterError) throw err;
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "albedo",
+          "USER_REJECTED",
+          "User closed the Albedo popup.",
+          err
+        );
+      }
+      throw this.normaliseError("CONNECTION_FAILED", err, "Failed to connect via Albedo.");
+    }
+  }
+
+  /**
+   * Albedo has no persistent session — always returns null.
+   * The user must explicitly connect each time.
+   */
+  async checkConnection(): Promise<string | null> {
+    return null;
+  }
+
+  async signTransaction(xdr: string, options?: SignOptions): Promise<string> {
+    try {
+      const response = await albedo.tx({
+        xdr,
+        network: options?.networkPassphrase?.toLowerCase().includes("public")
+          ? "public"
+          : "testnet",
+        submit: false,
+      });
+      if (!response?.signed_envelope_xdr) {
+        throw new WalletAdapterError(
+          "albedo",
+          "SIGN_FAILED",
+          "Albedo did not return a signed transaction."
+        );
+      }
+      return response.signed_envelope_xdr;
+    } catch (err) {
+      if (err instanceof WalletAdapterError) throw err;
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "albedo",
+          "USER_REJECTED",
+          "User rejected the Albedo signing request.",
+          err
+        );
+      }
+      throw this.normaliseError("SIGN_FAILED", err, "Albedo transaction signing failed.");
+    }
+  }
+}
+
+// ── Self-registration ─────────────────────────────────────────────────────────
+
+WalletAdapterRegistry.register("albedo", () => new AlbedoAdapter());

--- a/ide/src/lib/wallet/BaseAdapter.ts
+++ b/ide/src/lib/wallet/BaseAdapter.ts
@@ -1,0 +1,314 @@
+/**
+ * src/lib/wallet/BaseAdapter.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Dependency Injection for Wallet Connectors — Issue #644
+ *
+ * Defines the canonical `WalletAdapter` interface and the `BaseWalletAdapter`
+ * abstract class that all concrete wallet adapters must extend.
+ *
+ * Architecture
+ * ────────────
+ *  WalletAdapter (interface)         ← the contract every adapter fulfills
+ *       │
+ *  BaseWalletAdapter (abstract)      ← shared helpers, capability flags,
+ *       │                              error normalisation, lifecycle hooks
+ *       ├── FreighterAdapter          ← wraps @stellar/freighter-api
+ *       ├── AlbedoAdapter             ← wraps @albedo-link/intent
+ *       └── HanaAdapter               ← wraps window.hana (Hana Wallet extension)
+ *
+ * Usage
+ * ─────
+ *   import { FreighterAdapter } from "@/lib/wallet/FreighterAdapter";
+ *   import { WalletAdapterRegistry } from "@/lib/wallet/BaseAdapter";
+ *
+ *   // Auto-detect and connect
+ *   const adapter = WalletAdapterRegistry.get("freighter");
+ *   const publicKey = await adapter.connect();
+ *
+ *   // Or: inject any adapter at call-site
+ *   async function sign(adapter: WalletAdapter, xdr: string) {
+ *     return adapter.signTransaction(xdr, { networkPassphrase: "..." });
+ *   }
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** All known wallet provider identifiers. */
+export type WalletAdapterType = "freighter" | "albedo" | "hana";
+
+/** Options passed to signTransaction / signAuthEntry. */
+export interface SignOptions {
+  /** Stellar network passphrase (e.g. "Test SDF Network ; September 2015") */
+  networkPassphrase?: string;
+  /** Stellar public key of the signing account */
+  address?: string;
+}
+
+/** Structured result from a successful connection. */
+export interface ConnectResult {
+  /** G... Stellar public key of the connected account */
+  publicKey: string;
+  /** Human-readable wallet display name, if available */
+  displayName?: string;
+}
+
+/**
+ * Capability flags — tell consumers what the adapter supports
+ * without having to try/catch feature calls.
+ */
+export interface WalletCapabilities {
+  /** Can sign Stellar transactions (XDR envelope) */
+  canSignTransaction: boolean;
+  /** Can sign Soroban authorization entries */
+  canSignAuthEntry: boolean;
+  /** Can check whether a session already exists without a user popup */
+  canCheckConnection: boolean;
+  /** Whether the wallet is a browser extension vs. a web-popup flow */
+  isExtension: boolean;
+}
+
+/** Metadata about the wallet provider. */
+export interface WalletAdapterInfo {
+  /** Unique string identifier */
+  id: WalletAdapterType;
+  /** Human-readable name */
+  name: string;
+  /** Short description shown in wallet selector UI */
+  description: string;
+  /** Download / homepage URL */
+  url: string;
+  capabilities: WalletCapabilities;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core interface — ALL adapters must implement this
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Standardized WalletAdapter interface.
+ *
+ * Every method has a concrete, non-optional signature so consumers don't need
+ * to guard for `undefined`. Adapters that genuinely can't support a method
+ * (e.g. Albedo signing) should throw a descriptive `WalletAdapterError`.
+ */
+export interface WalletAdapter {
+  /** Static metadata — safe to read before connecting. */
+  readonly info: WalletAdapterInfo;
+
+  /**
+   * Check whether the wallet extension / provider is available in this browser.
+   * Does NOT trigger a connection popup.
+   */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Initiate a connection and return the connected account's public key.
+   * May open a browser popup.
+   */
+  connect(): Promise<ConnectResult>;
+
+  /**
+   * Check whether there is an existing active session.
+   * Returns the public key if connected, `null` otherwise.
+   * Never opens a popup.
+   */
+  checkConnection(): Promise<string | null>;
+
+  /**
+   * Disconnect / clear the active session.
+   * No-op if the wallet manages sessions externally (e.g. extensions).
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Sign a Stellar transaction XDR envelope.
+   * Returns the signed XDR string.
+   * Throws `WalletAdapterError` with code `UNSUPPORTED` if not supported.
+   */
+  signTransaction(xdr: string, options?: SignOptions): Promise<string>;
+
+  /**
+   * Sign a Soroban authorization entry XDR.
+   * Returns the signed entry XDR string.
+   * Throws `WalletAdapterError` with code `UNSUPPORTED` if not supported.
+   */
+  signAuthEntry(entryXdr: string, options?: SignOptions): Promise<string>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typed error class
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type WalletAdapterErrorCode =
+  | "NOT_AVAILABLE"     // Extension/provider not installed
+  | "CONNECTION_FAILED" // connect() call failed
+  | "USER_REJECTED"     // User dismissed / cancelled the popup
+  | "SIGN_FAILED"       // Transaction / auth-entry signing failed
+  | "UNSUPPORTED"       // Feature not supported by this provider
+  | "UNKNOWN";          // Catch-all
+
+export class WalletAdapterError extends Error {
+  readonly code: WalletAdapterErrorCode;
+  readonly adapter: WalletAdapterType;
+  readonly cause?: unknown;
+
+  constructor(
+    adapter: WalletAdapterType,
+    code: WalletAdapterErrorCode,
+    message: string,
+    cause?: unknown
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = "WalletAdapterError";
+    this.code = code;
+    this.adapter = adapter;
+    this.cause = cause;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Abstract base — shared helpers that concrete adapters inherit
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Abstract base class for all wallet adapters.
+ *
+ * Concrete adapters extend this and only override the methods they need to.
+ * Unsupported operations automatically throw a well-typed `WalletAdapterError`.
+ */
+export abstract class BaseWalletAdapter implements WalletAdapter {
+  abstract readonly info: WalletAdapterInfo;
+
+  // Subclasses implement these two
+  abstract isAvailable(): Promise<boolean>;
+  abstract connect(): Promise<ConnectResult>;
+
+  /** Default: no persistent session check. Override when supported. */
+  async checkConnection(): Promise<string | null> {
+    return null;
+  }
+
+  /** Default: no-op disconnect. Override for session-aware providers. */
+  async disconnect(): Promise<void> {
+    // no-op by default
+  }
+
+  /** Default: throws UNSUPPORTED. Override in adapters that can sign. */
+  async signTransaction(_xdr: string, _options?: SignOptions): Promise<string> {
+    throw new WalletAdapterError(
+      this.info.id,
+      "UNSUPPORTED",
+      `${this.info.name} does not support transaction signing.`
+    );
+  }
+
+  /** Default: throws UNSUPPORTED. Override in adapters that can sign auth entries. */
+  async signAuthEntry(_entryXdr: string, _options?: SignOptions): Promise<string> {
+    throw new WalletAdapterError(
+      this.info.id,
+      "UNSUPPORTED",
+      `${this.info.name} does not support auth entry signing.`
+    );
+  }
+
+  // ── Shared helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Normalise any thrown value into a `WalletAdapterError`.
+   * Useful inside catch blocks to ensure typed errors propagate upward.
+   */
+  protected normaliseError(
+    code: WalletAdapterErrorCode,
+    err: unknown,
+    fallbackMessage: string
+  ): WalletAdapterError {
+    let message: string;
+    if (err instanceof Error) {
+      message = err.message || fallbackMessage;
+    } else {
+      const coerced = String(err ?? "");
+      message = coerced && coerced !== "null" && coerced !== "undefined"
+        ? coerced
+        : fallbackMessage;
+    }
+    return new WalletAdapterError(this.info.id, code, message, err);
+  }
+
+  /**
+   * Detect common user-rejection signals across wallet SDKs.
+   * Returns true if `err` looks like a user cancellation.
+   */
+  protected isUserRejection(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message.toLowerCase();
+    return (
+      msg.includes("user rejected") ||
+      msg.includes("user cancelled") ||
+      msg.includes("user denied") ||
+      msg.includes("closed") ||
+      msg.includes("cancel")
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registry — DI container for adapter instances
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AdapterFactory = () => WalletAdapter;
+
+/**
+ * Global adapter registry.
+ *
+ * Adapters register themselves at module load time; consumers retrieve them
+ * by provider key. This is the dependency-injection entry-point:
+ *
+ *   const adapter = WalletAdapterRegistry.get("freighter");
+ *
+ * Custom / third-party adapters can be added at runtime:
+ *
+ *   WalletAdapterRegistry.register("myWallet" as WalletAdapterType, () => new MyAdapter());
+ */
+export class WalletAdapterRegistry {
+  private static readonly factories = new Map<string, AdapterFactory>();
+  private static readonly cache    = new Map<string, WalletAdapter>();
+
+  /** Register a factory function for an adapter type. */
+  static register(type: string, factory: AdapterFactory): void {
+    this.factories.set(type, factory);
+    this.cache.delete(type); // invalidate any cached instance
+  }
+
+  /**
+   * Retrieve the adapter for a given type.
+   * Instances are cached (singleton-per-type) after first creation.
+   */
+  static get(type: WalletAdapterType | string): WalletAdapter {
+    if (this.cache.has(type)) return this.cache.get(type)!;
+    const factory = this.factories.get(type);
+    if (!factory) {
+      throw new WalletAdapterError(
+        type as WalletAdapterType,
+        "NOT_AVAILABLE",
+        `No adapter registered for wallet type "${type}".`
+      );
+    }
+    const instance = factory();
+    this.cache.set(type, instance);
+    return instance;
+  }
+
+  /** Returns all registered type keys. */
+  static registered(): string[] {
+    return [...this.factories.keys()];
+  }
+
+  /** Clear cached instances (useful for testing). */
+  static clearCache(): void {
+    this.cache.clear();
+  }
+}

--- a/ide/src/lib/wallet/FreighterAdapter.ts
+++ b/ide/src/lib/wallet/FreighterAdapter.ts
@@ -1,0 +1,99 @@
+/**
+ * src/lib/wallet/FreighterAdapter.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WalletAdapter implementation for the Freighter browser extension.
+ * Wraps the existing `@/utils/freighter` helpers so no code is duplicated.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import {
+  BaseWalletAdapter,
+  WalletAdapterRegistry,
+  WalletAdapterError,
+  type ConnectResult,
+  type SignOptions,
+  type WalletAdapterInfo,
+} from "./BaseAdapter";
+import {
+  connectFreighterWallet,
+  getFreighterPublicKey,
+  checkFreighterInstalled,
+  signFreighterTransaction,
+} from "@/utils/freighter";
+
+// ── Metadata ─────────────────────────────────────────────────────────────────
+
+const FREIGHTER_INFO: WalletAdapterInfo = {
+  id: "freighter",
+  name: "Freighter",
+  description: "Official Stellar browser extension wallet by SDF.",
+  url: "https://www.freighter.app",
+  capabilities: {
+    canSignTransaction: true,
+    canSignAuthEntry: false, // Freighter does not yet expose signAuthEntry via API
+    canCheckConnection: true,
+    isExtension: true,
+  },
+};
+
+// ── Adapter ───────────────────────────────────────────────────────────────────
+
+export class FreighterAdapter extends BaseWalletAdapter {
+  readonly info: WalletAdapterInfo = FREIGHTER_INFO;
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      return await checkFreighterInstalled();
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<ConnectResult> {
+    try {
+      const publicKey = await connectFreighterWallet();
+      return { publicKey };
+    } catch (err) {
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "freighter",
+          "USER_REJECTED",
+          "User rejected the Freighter connection request.",
+          err
+        );
+      }
+      throw this.normaliseError("CONNECTION_FAILED", err, "Failed to connect Freighter.");
+    }
+  }
+
+  async checkConnection(): Promise<string | null> {
+    try {
+      const installed = await checkFreighterInstalled();
+      if (!installed) return null;
+      const key = await getFreighterPublicKey();
+      return key || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async signTransaction(xdr: string, options?: SignOptions): Promise<string> {
+    try {
+      return await signFreighterTransaction(xdr, options);
+    } catch (err) {
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "freighter",
+          "USER_REJECTED",
+          "User rejected the Freighter signing request.",
+          err
+        );
+      }
+      throw this.normaliseError("SIGN_FAILED", err, "Freighter transaction signing failed.");
+    }
+  }
+}
+
+// ── Self-registration ─────────────────────────────────────────────────────────
+
+WalletAdapterRegistry.register("freighter", () => new FreighterAdapter());

--- a/ide/src/lib/wallet/HanaAdapter.ts
+++ b/ide/src/lib/wallet/HanaAdapter.ts
@@ -1,0 +1,181 @@
+/**
+ * src/lib/wallet/HanaAdapter.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WalletAdapter implementation for the Hana Wallet browser extension.
+ *
+ * Hana exposes a `window.hana` object that mirrors the Freighter API shape.
+ * Reference: https://docs.hanawallet.io/
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import {
+  BaseWalletAdapter,
+  WalletAdapterRegistry,
+  WalletAdapterError,
+  type ConnectResult,
+  type SignOptions,
+  type WalletAdapterInfo,
+} from "./BaseAdapter";
+
+// ── Hana window type augmentation ─────────────────────────────────────────────
+
+interface HanaProvider {
+  isHana?: boolean;
+  getPublicKey(): Promise<string>;
+  isConnected(): Promise<boolean>;
+  signTransaction(
+    transactionXdr: string,
+    opts?: { networkPassphrase?: string }
+  ): Promise<{ signedTxXdr: string }>;
+  signAuthEntry(
+    entryXdr: string,
+    opts?: { networkPassphrase?: string; address?: string }
+  ): Promise<{ signedAuthEntry: string }>;
+}
+
+declare global {
+  interface Window {
+    hana?: HanaProvider;
+  }
+}
+
+// ── Metadata ─────────────────────────────────────────────────────────────────
+
+const HANA_INFO: WalletAdapterInfo = {
+  id: "hana",
+  name: "Hana",
+  description: "Hana Wallet — Stellar & Soroban browser extension.",
+  url: "https://hanawallet.io",
+  capabilities: {
+    canSignTransaction: true,
+    canSignAuthEntry: true, // Hana supports Soroban auth entry signing
+    canCheckConnection: true,
+    isExtension: true,
+  },
+};
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+function getHanaProvider(): HanaProvider {
+  if (typeof window === "undefined" || !window.hana) {
+    throw new WalletAdapterError(
+      "hana",
+      "NOT_AVAILABLE",
+      "Hana Wallet extension is not installed. Install it from hanawallet.io."
+    );
+  }
+  return window.hana;
+}
+
+// ── Adapter ───────────────────────────────────────────────────────────────────
+
+export class HanaAdapter extends BaseWalletAdapter {
+  readonly info: WalletAdapterInfo = HANA_INFO;
+
+  async isAvailable(): Promise<boolean> {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.hana !== "undefined" &&
+      window.hana.isHana === true
+    );
+  }
+
+  async connect(): Promise<ConnectResult> {
+    try {
+      const hana = getHanaProvider();
+      const publicKey = await hana.getPublicKey();
+      if (!publicKey) {
+        throw new WalletAdapterError(
+          "hana",
+          "CONNECTION_FAILED",
+          "Hana did not return a public key."
+        );
+      }
+      return { publicKey };
+    } catch (err) {
+      if (err instanceof WalletAdapterError) throw err;
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "hana",
+          "USER_REJECTED",
+          "User rejected the Hana connection request.",
+          err
+        );
+      }
+      throw this.normaliseError("CONNECTION_FAILED", err, "Failed to connect to Hana Wallet.");
+    }
+  }
+
+  async checkConnection(): Promise<string | null> {
+    try {
+      const hana = getHanaProvider();
+      const connected = await hana.isConnected();
+      if (!connected) return null;
+      const publicKey = await hana.getPublicKey();
+      return publicKey || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async signTransaction(xdr: string, options?: SignOptions): Promise<string> {
+    try {
+      const hana = getHanaProvider();
+      const result = await hana.signTransaction(xdr, {
+        networkPassphrase: options?.networkPassphrase,
+      });
+      if (!result?.signedTxXdr) {
+        throw new WalletAdapterError(
+          "hana",
+          "SIGN_FAILED",
+          "Hana did not return a signed transaction."
+        );
+      }
+      return result.signedTxXdr;
+    } catch (err) {
+      if (err instanceof WalletAdapterError) throw err;
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "hana",
+          "USER_REJECTED",
+          "User rejected the Hana signing request.",
+          err
+        );
+      }
+      throw this.normaliseError("SIGN_FAILED", err, "Hana transaction signing failed.");
+    }
+  }
+
+  async signAuthEntry(entryXdr: string, options?: SignOptions): Promise<string> {
+    try {
+      const hana = getHanaProvider();
+      const result = await hana.signAuthEntry(entryXdr, {
+        networkPassphrase: options?.networkPassphrase,
+        address: options?.address,
+      });
+      if (!result?.signedAuthEntry) {
+        throw new WalletAdapterError(
+          "hana",
+          "SIGN_FAILED",
+          "Hana did not return a signed auth entry."
+        );
+      }
+      return result.signedAuthEntry;
+    } catch (err) {
+      if (err instanceof WalletAdapterError) throw err;
+      if (this.isUserRejection(err)) {
+        throw new WalletAdapterError(
+          "hana",
+          "USER_REJECTED",
+          "User rejected the Hana auth-entry signing request.",
+          err
+        );
+      }
+      throw this.normaliseError("SIGN_FAILED", err, "Hana auth entry signing failed.");
+    }
+  }
+}
+
+// ── Self-registration ─────────────────────────────────────────────────────────
+
+WalletAdapterRegistry.register("hana", () => new HanaAdapter());

--- a/ide/src/lib/wallet/__tests__/BaseAdapter.test.ts
+++ b/ide/src/lib/wallet/__tests__/BaseAdapter.test.ts
@@ -1,0 +1,275 @@
+/**
+ * src/lib/wallet/__tests__/BaseAdapter.test.ts
+ * Unit tests for the wallet adapter framework — Issue #644
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  BaseWalletAdapter,
+  WalletAdapterRegistry,
+  WalletAdapterError,
+  type WalletAdapterInfo,
+  type ConnectResult,
+} from "../BaseAdapter";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test double — minimal concrete adapter
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_INFO: WalletAdapterInfo = {
+  id: "freighter",
+  name: "Mock Wallet",
+  description: "Test double",
+  url: "https://example.com",
+  capabilities: {
+    canSignTransaction: true,
+    canSignAuthEntry: false,
+    canCheckConnection: true,
+    isExtension: true,
+  },
+};
+
+class MockAdapter extends BaseWalletAdapter {
+  readonly info = MOCK_INFO;
+  private _available = true;
+  private _publicKey = "GABC1234";
+
+  setAvailable(v: boolean) { this._available = v; }
+  setPublicKey(k: string) { this._publicKey = k; }
+
+  async isAvailable() { return this._available; }
+  async connect(): Promise<ConnectResult> {
+    if (!this._available) {
+      throw new WalletAdapterError("freighter", "NOT_AVAILABLE", "Not installed.");
+    }
+    return { publicKey: this._publicKey };
+  }
+  async checkConnection() { return this._available ? this._publicKey : null; }
+  async signTransaction(xdr: string) { return `signed:${xdr}`; }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WalletAdapterError
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("WalletAdapterError", () => {
+  it("has the correct name and code", () => {
+    const err = new WalletAdapterError("freighter", "CONNECTION_FAILED", "test message");
+    expect(err.name).toBe("WalletAdapterError");
+    expect(err.code).toBe("CONNECTION_FAILED");
+    expect(err.adapter).toBe("freighter");
+    expect(err.message).toBe("test message");
+  });
+
+  it("instanceof Error is true", () => {
+    expect(new WalletAdapterError("albedo", "UNKNOWN", "x") instanceof Error).toBe(true);
+  });
+
+  it("stores optional cause", () => {
+    const cause = new Error("root cause");
+    const err = new WalletAdapterError("hana", "SIGN_FAILED", "wrapped", cause);
+    expect(err.cause).toBe(cause);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BaseWalletAdapter defaults
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("BaseWalletAdapter defaults", () => {
+  let adapter: MockAdapter;
+  beforeEach(() => { adapter = new MockAdapter(); });
+
+  it("connect returns a ConnectResult with publicKey", async () => {
+    const result = await adapter.connect();
+    expect(result.publicKey).toBe("GABC1234");
+  });
+
+  it("checkConnection returns publicKey when available", async () => {
+    const key = await adapter.checkConnection();
+    expect(key).toBe("GABC1234");
+  });
+
+  it("checkConnection returns null when unavailable", async () => {
+    adapter.setAvailable(false);
+    const key = await adapter.checkConnection();
+    expect(key).toBeNull();
+  });
+
+  it("signTransaction is overridden in MockAdapter", async () => {
+    const result = await adapter.signTransaction("xdr123");
+    expect(result).toBe("signed:xdr123");
+  });
+
+  it("signAuthEntry throws UNSUPPORTED by default", async () => {
+    await expect(adapter.signAuthEntry("entry")).rejects.toMatchObject({
+      code: "UNSUPPORTED",
+      name: "WalletAdapterError",
+    });
+  });
+
+  it("disconnect resolves without error (no-op)", async () => {
+    await expect(adapter.disconnect()).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normaliseError helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("BaseWalletAdapter.normaliseError", () => {
+  class ExposedAdapter extends MockAdapter {
+    public expose_normaliseError(code: Parameters<typeof this.normaliseError>[0], err: unknown, msg: string) {
+      return this.normaliseError(code, err, msg);
+    }
+    public expose_isUserRejection(err: unknown) {
+      return this.isUserRejection(err);
+    }
+  }
+
+  let adapter: ExposedAdapter;
+  beforeEach(() => { adapter = new ExposedAdapter(); });
+
+  it("wraps an Error cause with its message", () => {
+    const cause = new Error("original");
+    const result = adapter.expose_normaliseError("CONNECTION_FAILED", cause, "fallback");
+    expect(result.message).toBe("original");
+    expect(result.code).toBe("CONNECTION_FAILED");
+  });
+
+  it("uses fallbackMessage when cause is not an Error", () => {
+    const result = adapter.expose_normaliseError("UNKNOWN", "raw string", "fallback msg");
+    expect(result.message).toBe("raw string");
+  });
+
+  it("uses fallbackMessage for null cause", () => {
+    const result = adapter.expose_normaliseError("UNKNOWN", null, "fallback msg");
+    expect(result.message).toBe("fallback msg");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isUserRejection helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("BaseWalletAdapter.isUserRejection", () => {
+  class ExposedAdapter extends MockAdapter {
+    public check(err: unknown) { return this.isUserRejection(err); }
+  }
+  const adapter = new ExposedAdapter();
+
+  it("returns true for 'user rejected' message", () => {
+    expect(adapter.check(new Error("User rejected the request"))).toBe(true);
+  });
+  it("returns true for 'user cancelled'", () => {
+    expect(adapter.check(new Error("user cancelled"))).toBe(true);
+  });
+  it("returns true for 'closed'", () => {
+    expect(adapter.check(new Error("popup closed"))).toBe(true);
+  });
+  it("returns false for generic errors", () => {
+    expect(adapter.check(new Error("network timeout"))).toBe(false);
+  });
+  it("returns false for non-Error values", () => {
+    expect(adapter.check("string error")).toBe(false);
+    expect(adapter.check(null)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WalletAdapterRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("WalletAdapterRegistry", () => {
+  beforeEach(() => {
+    WalletAdapterRegistry.clearCache();
+  });
+
+  it("register + get returns the adapter", () => {
+    WalletAdapterRegistry.register("freighter", () => new MockAdapter());
+    const adapter = WalletAdapterRegistry.get("freighter");
+    expect(adapter).toBeInstanceOf(MockAdapter);
+  });
+
+  it("returns the same cached instance on repeated get", () => {
+    WalletAdapterRegistry.register("freighter", () => new MockAdapter());
+    const a = WalletAdapterRegistry.get("freighter");
+    const b = WalletAdapterRegistry.get("freighter");
+    expect(a).toBe(b);
+  });
+
+  it("throws NOT_AVAILABLE for unknown type", () => {
+    expect(() => WalletAdapterRegistry.get("unknown_wallet" as never)).toThrow(
+      WalletAdapterError
+    );
+    try {
+      WalletAdapterRegistry.get("unknown_wallet" as never);
+    } catch (e) {
+      expect((e as WalletAdapterError).code).toBe("NOT_AVAILABLE");
+    }
+  });
+
+  it("clearCache forces new instance creation", () => {
+    WalletAdapterRegistry.register("freighter", () => new MockAdapter());
+    const a = WalletAdapterRegistry.get("freighter");
+    WalletAdapterRegistry.clearCache();
+    const b = WalletAdapterRegistry.get("freighter");
+    expect(a).not.toBe(b);
+  });
+
+  it("registered() lists all registered keys", () => {
+    WalletAdapterRegistry.register("albedo", () => new MockAdapter());
+    WalletAdapterRegistry.register("hana", () => new MockAdapter());
+    const keys = WalletAdapterRegistry.registered();
+    expect(keys).toContain("albedo");
+    expect(keys).toContain("hana");
+  });
+
+  it("register invalidates existing cache for that type", () => {
+    WalletAdapterRegistry.register("freighter", () => new MockAdapter());
+    const a = WalletAdapterRegistry.get("freighter");
+    // Re-register with a different factory
+    WalletAdapterRegistry.register("freighter", () => {
+      const m = new MockAdapter();
+      m.setPublicKey("GNEW");
+      return m;
+    });
+    const b = WalletAdapterRegistry.get("freighter");
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WalletAdapter interface contract (via MockAdapter)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("WalletAdapter interface contract", () => {
+  it("info.capabilities.canSignTransaction matches actual behaviour", async () => {
+    const adapter = new MockAdapter();
+    if (adapter.info.capabilities.canSignTransaction) {
+      await expect(adapter.signTransaction("xdr")).resolves.toBeTruthy();
+    }
+  });
+
+  it("info.capabilities.canSignAuthEntry=false leads to UNSUPPORTED error", async () => {
+    const adapter = new MockAdapter();
+    expect(adapter.info.capabilities.canSignAuthEntry).toBe(false);
+    await expect(adapter.signAuthEntry("entry")).rejects.toMatchObject({
+      code: "UNSUPPORTED",
+    });
+  });
+
+  it("canCheckConnection=true means checkConnection does not throw", async () => {
+    const adapter = new MockAdapter();
+    expect(adapter.info.capabilities.canCheckConnection).toBe(true);
+    await expect(adapter.checkConnection()).resolves.not.toThrow();
+  });
+
+  it("isAvailable reflects extension presence flag", async () => {
+    const adapter = new MockAdapter();
+    adapter.setAvailable(false);
+    expect(await adapter.isAvailable()).toBe(false);
+    adapter.setAvailable(true);
+    expect(await adapter.isAvailable()).toBe(true);
+  });
+});

--- a/ide/src/lib/wallet/albedo.d.ts
+++ b/ide/src/lib/wallet/albedo.d.ts
@@ -1,0 +1,35 @@
+/**
+ * src/lib/wallet/albedo.d.ts
+ * Manual ambient declaration for @albedo-link/intent.
+ * The package ships no TypeScript types; this covers the subset used
+ * by AlbedoAdapter (publicKey + tx intents).
+ */
+declare module "@albedo-link/intent" {
+  interface PublicKeyParams {
+    token?: string;
+  }
+  interface PublicKeyResult {
+    pubkey: string;
+    token?: string;
+  }
+
+  interface TxParams {
+    xdr: string;
+    network?: "public" | "testnet";
+    submit?: boolean;
+    token?: string;
+  }
+  interface TxResult {
+    signed_envelope_xdr: string;
+    tx_hash?: string;
+    network?: string;
+  }
+
+  interface Albedo {
+    publicKey(params?: PublicKeyParams): Promise<PublicKeyResult>;
+    tx(params: TxParams): Promise<TxResult>;
+  }
+
+  const albedo: Albedo;
+  export default albedo;
+}

--- a/ide/src/lib/wallet/index.ts
+++ b/ide/src/lib/wallet/index.ts
@@ -1,0 +1,18 @@
+/**
+ * src/lib/wallet/index.ts
+ * Public barrel — import everything from one path.
+ *
+ *   import {
+ *     WalletAdapterRegistry,
+ *     FreighterAdapter, AlbedoAdapter, HanaAdapter,
+ *     WalletAdapterError,
+ *   } from "@/lib/wallet";
+ */
+
+// Core interface, base class, registry, and error
+export * from "./BaseAdapter";
+
+// Concrete adapters (importing triggers self-registration)
+export * from "./FreighterAdapter";
+export * from "./AlbedoAdapter";
+export * from "./HanaAdapter";


### PR DESCRIPTION
## Summary
Closes #644  — Dependency Injection for Wallet Connectors

## Deliverables
- `src/lib/wallet/BaseAdapter.ts` — `WalletAdapter` interface, `BaseWalletAdapter` abstract class, `WalletAdapterError`, `WalletAdapterRegistry` DI container
- `src/lib/wallet/FreighterAdapter.ts` — Freighter extension adapter
- `src/lib/wallet/AlbedoAdapter.ts` — Albedo web-popup adapter
- `src/lib/wallet/HanaAdapter.ts` — Hana extension adapter (new provider)
- `src/lib/wallet/albedo.d.ts` — ambient type declaration for `@albedo-link/intent` (no bundled types)
- `src/lib/wallet/index.ts` — barrel export
- `src/lib/wallet/__tests__/BaseAdapter.test.ts` — 27 tests

## What Changed

**`WalletAdapter` interface** — standardized contract:
`isAvailable`, `connect`, `checkConnection`, `disconnect`, `signTransaction`, `signAuthEntry` — all non-optional; unsupported methods throw `WalletAdapterError(UNSUPPORTED)`

**`WalletCapabilities` flags** — `canSignTransaction`, `canSignAuthEntry`, `canCheckConnection`, `isExtension` — no feature-probing try/catch in consumers

**`BaseWalletAdapter`** — shared `normaliseError()` and `isUserRejection()` helpers; sensible no-op / UNSUPPORTED defaults

**`WalletAdapterError`** — typed error codes: `NOT_AVAILABLE | CONNECTION_FAILED | USER_REJECTED | SIGN_FAILED | UNSUPPORTED | UNKNOWN`

**`WalletAdapterRegistry`** — DI container: `register(type, factory)` / `get(type)` with singleton cache; any future wallet (xBull, Rabet…) plugs in without touching existing code

**Adapters:**
- `FreighterAdapter` — wraps existing `@/utils/freighter` helpers, adds typed error classification
- `AlbedoAdapter` — `signTransaction` via `albedo.tx()`, `checkConnection` always `null` (no persistent session)
- `HanaAdapter` — new; uses `window.hana` with full TS type augmentation; supports `signAuthEntry` for Soroban contracts

## Verified Terminal Output
