### PR TITLE
feat: versioned-state-persistence

### DIFF
--- a/ide/src/lib/store/VersionedPersistence.ts
+++ b/ide/src/lib/store/VersionedPersistence.ts
@@ -1,0 +1,408 @@
+/**
+ * src/lib/store/VersionedPersistence.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Scalable State Serialization — Issue #648
+ *
+ * Provides a generic, versioned persistence layer that wraps any storage
+ * backend (localStorage, IndexedDB, etc.) and adds:
+ *
+ *  1. VERSION TAGGING — every serialized snapshot carries a `_version` field
+ *     so stale data is always identifiable.
+ *
+ *  2. MIGRATION ENGINE — a declarative chain of migration functions transforms
+ *     old state forward, one version at a time, until it reaches the current
+ *     schema version.
+ *
+ *  3. BACKWARDS COMPATIBILITY — unrecognised or corrupt data is never silently
+ *     swallowed; the engine falls back to `null` (which triggers store
+ *     initialisation with defaults) and fires a recoverable error event.
+ *
+ *  4. ZUSTAND INTEGRATION — `createVersionedStorage()` returns a drop-in
+ *     replacement for `createJSONStorage(...)` so any Zustand store can opt
+ *     into versioned persistence in one line.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Usage example
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ *   import { createVersionedStorage } from "@/lib/store/VersionedPersistence";
+ *
+ *   const CURRENT_VERSION = 3;
+ *
+ *   const migrations: MigrationMap = {
+ *     // v1 → v2: rename 'rpc' to 'rpcUrl'
+ *     2: (old) => ({ ...old, rpcUrl: old.rpc, rpc: undefined }),
+ *     // v2 → v3: add default 'customHeaders' field
+ *     3: (old) => ({ ...old, customHeaders: old.customHeaders ?? {} }),
+ *   };
+ *
+ *   export const useMyStore = create()(
+ *     persist(
+ *       (set) => ({ ... }),
+ *       {
+ *         name: "my-store-key",
+ *         storage: createVersionedStorage(
+ *           () => localStorage,
+ *           CURRENT_VERSION,
+ *           migrations
+ *         ),
+ *       }
+ *     )
+ *   );
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single migration function.
+ * Receives the raw state at the *previous* version and returns the state
+ * transformed to the *target* version.
+ *
+ * The `unknown` input type is intentional — migrations must be defensive
+ * because the incoming data may be malformed.
+ */
+export type MigrationFn = (state: unknown) => unknown;
+
+/**
+ * A map of version number → migration function.
+ * Key `n` means "migrate state from version n-1 to version n".
+ *
+ * @example
+ * const migrations: MigrationMap = {
+ *   2: (s) => ({ ...(s as Record<string,unknown>), newField: "default" }),
+ *   3: (s) => { const next = { ...(s as Record<string,unknown>) }; delete next.legacyField; return next; },
+ * };
+ */
+export type MigrationMap = Record<number, MigrationFn>;
+
+/**
+ * The envelope written to storage.
+ * `_version` is the schema version at the time of writing.
+ * `state` is the partial store state (after `partialize`, if any).
+ */
+export interface VersionedSnapshot<T = unknown> {
+  _version: number;
+  state: T;
+  _migratedAt?: string;  // ISO timestamp, set after a migration pass
+}
+
+/** Result returned by `migrateState` */
+export interface MigrationResult<T = unknown> {
+  state: T;
+  /** Number of migration steps actually applied (0 = already current) */
+  stepsApplied: number;
+  /** Final version after migration */
+  version: number;
+}
+
+/**
+ * Options for `createVersionedStorage`.
+ */
+export interface VersionedStorageOptions {
+  /**
+   * Called when a migration is applied.
+   * Useful for analytics / logging without coupling to a logger.
+   */
+  onMigrate?: (fromVersion: number, toVersion: number, key: string) => void;
+  /**
+   * Called when data is corrupt or unrecoverable.
+   * The storage layer discards the data and returns `null`.
+   */
+  onCorrupt?: (reason: string, key: string, raw: unknown) => void;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migration engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run all necessary migrations to bring `state` from `fromVersion` up to
+ * `targetVersion`.
+ *
+ * Migration functions are applied in ascending version order, so adding a
+ * version 5 migration never requires touching the version 3 or 4 functions.
+ *
+ * @throws {VersionedPersistenceError} if a required migration step is missing
+ */
+export function migrateState<T = unknown>(
+  state: unknown,
+  fromVersion: number,
+  targetVersion: number,
+  migrations: MigrationMap
+): MigrationResult<T> {
+  if (fromVersion === targetVersion) {
+    return { state: state as T, stepsApplied: 0, version: targetVersion };
+  }
+
+  if (fromVersion > targetVersion) {
+    throw new VersionedPersistenceError(
+      `Stored version (${fromVersion}) is newer than the current schema version (${targetVersion}). ` +
+        "This usually means the app was downgraded. Clear storage to continue.",
+      "FUTURE_VERSION"
+    );
+  }
+
+  let current = state;
+  let stepsApplied = 0;
+
+  for (let v = fromVersion + 1; v <= targetVersion; v++) {
+    const fn = migrations[v];
+    if (!fn) {
+      throw new VersionedPersistenceError(
+        `Missing migration for version ${v}. ` +
+          `Cannot migrate from v${fromVersion} to v${targetVersion}.`,
+        "MISSING_MIGRATION"
+      );
+    }
+    current = fn(current);
+    stepsApplied++;
+  }
+
+  return { state: current as T, stepsApplied, version: targetVersion };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Serialization helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Wrap a state value in a versioned envelope.
+ * This is what gets written to storage.
+ */
+export function wrapSnapshot<T>(state: T, version: number): VersionedSnapshot<T> {
+  return { _version: version, state };
+}
+
+/**
+ * Parse and validate a raw storage string into a `VersionedSnapshot`.
+ * Returns `null` if the string is empty, invalid JSON, or missing required fields.
+ */
+export function parseSnapshot(raw: string | null): VersionedSnapshot | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("state" in parsed) ||
+      !("_version" in parsed) ||
+      typeof (parsed as VersionedSnapshot)._version !== "number"
+    ) {
+      return null;
+    }
+    return parsed as VersionedSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typed error
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type VersionedPersistenceErrorCode =
+  | "FUTURE_VERSION"
+  | "MISSING_MIGRATION"
+  | "CORRUPT_DATA"
+  | "STORAGE_ERROR";
+
+export class VersionedPersistenceError extends Error {
+  readonly code: VersionedPersistenceErrorCode;
+  constructor(message: string, code: VersionedPersistenceErrorCode) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = "VersionedPersistenceError";
+    this.code = code;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Storage backend interface (compatible with Zustand's StateStorage)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface StorageBackend {
+  getItem(key: string): string | null | Promise<string | null>;
+  setItem(key: string, value: string): void | Promise<void>;
+  removeItem(key: string): void | Promise<void>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zustand-compatible versioned storage factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a Zustand-compatible storage object that transparently handles
+ * versioning and migrations.
+ *
+ * Drop this in as the `storage` option of any Zustand `persist` middleware:
+ *
+ * ```ts
+ * persist(fn, {
+ *   name: "my-key",
+ *   storage: createVersionedStorage(() => localStorage, 3, migrations),
+ * })
+ * ```
+ *
+ * @param getStorage  Lazy factory returning the underlying storage backend
+ * @param version     Current schema version (increment when state shape changes)
+ * @param migrations  Map of version → migration function
+ * @param options     Optional callbacks for migrate/corrupt events
+ */
+export function createVersionedStorage<T = unknown>(
+  getStorage: () => StorageBackend,
+  version: number,
+  migrations: MigrationMap = {},
+  options: VersionedStorageOptions = {}
+) {
+  const { onMigrate, onCorrupt } = options;
+
+  return {
+    async getItem(key: string): Promise<{ state: T; version?: number } | null> {
+      let raw: string | null;
+      try {
+        raw = (await getStorage().getItem(key)) as string | null;
+      } catch (err) {
+        onCorrupt?.("storage-read-error", key, err);
+        return null;
+      }
+
+      if (!raw) return null;
+
+      // ── Detect legacy (unversioned) payloads ─────────────────────────────
+      // Older stores wrote raw JSON without _version — treat them as version 0.
+      let snapshot = parseSnapshot(raw);
+      if (snapshot === null) {
+        // Try treating the entire raw value as a pre-versioning state blob
+        try {
+          const legacy = JSON.parse(raw) as unknown;
+          snapshot = { _version: 0, state: legacy };
+        } catch {
+          onCorrupt?.("corrupt-json", key, raw);
+          return null;
+        }
+      }
+
+      const storedVersion = snapshot._version;
+
+      if (storedVersion === version) {
+        // Already current — fast path
+        return { state: snapshot.state as T, version };
+      }
+
+      // ── Run migration engine ──────────────────────────────────────────────
+      try {
+        const result = migrateState<T>(
+          snapshot.state,
+          storedVersion,
+          version,
+          migrations
+        );
+
+        if (result.stepsApplied > 0) {
+          onMigrate?.(storedVersion, version, key);
+          // Persist the migrated state immediately so a refresh doesn't re-migrate
+          const upgraded: VersionedSnapshot<T> = {
+            _version: version,
+            state: result.state,
+            _migratedAt: new Date().toISOString(),
+          };
+          await getStorage().setItem(key, JSON.stringify(upgraded));
+        }
+
+        return { state: result.state, version };
+      } catch (err) {
+        const msg =
+          err instanceof VersionedPersistenceError
+            ? err.message
+            : "Migration failed unexpectedly.";
+        onCorrupt?.(msg, key, snapshot);
+        console.error("[VersionedPersistence] Migration failed:", err);
+        return null;
+      }
+    },
+
+    async setItem(key: string, value: { state: T; version?: number }): Promise<void> {
+      const snapshot: VersionedSnapshot<T> = {
+        _version: version,
+        state: value.state,
+      };
+      await getStorage().setItem(key, JSON.stringify(snapshot));
+    },
+
+    async removeItem(key: string): Promise<void> {
+      await getStorage().removeItem(key);
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Convenience: migration builder DSL
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fluent builder for assembling a `MigrationMap` step-by-step.
+ * Ensures no version is registered twice and versions are sequential.
+ *
+ * @example
+ * const migrations = new MigrationBuilder()
+ *   .add(2, (s) => ({ ...s, newField: "default" }))
+ *   .add(3, (s) => { const n = { ...s }; delete n.oldField; return n; })
+ *   .build();
+ */
+export class MigrationBuilder {
+  private readonly map: MigrationMap = {};
+  private lastVersion = 1;
+
+  /**
+   * Register a migration function that upgrades state TO the given `targetVersion`.
+   * Versions must be registered in ascending order.
+   */
+  add(targetVersion: number, fn: MigrationFn): this {
+    if (targetVersion <= this.lastVersion && Object.keys(this.map).length > 0) {
+      throw new VersionedPersistenceError(
+        `Migration versions must be registered in ascending order. ` +
+          `Got ${targetVersion} after ${this.lastVersion}.`,
+        "MISSING_MIGRATION"
+      );
+    }
+    if (this.map[targetVersion]) {
+      throw new VersionedPersistenceError(
+        `A migration for version ${targetVersion} is already registered.`,
+        "MISSING_MIGRATION"
+      );
+    }
+    this.map[targetVersion] = fn;
+    this.lastVersion = targetVersion;
+    return this;
+  }
+
+  /** Returns the assembled MigrationMap. */
+  build(): MigrationMap {
+    return { ...this.map };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Convenience: check if a stored key needs migration (without hydrating)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Peek at a storage key and return the stored version number,
+ * or `null` if the key doesn't exist / is unversioned / is corrupt.
+ */
+export async function peekStoredVersion(
+  storage: StorageBackend,
+  key: string
+): Promise<number | null> {
+  try {
+    const raw = (await storage.getItem(key)) as string | null;
+    const snapshot = parseSnapshot(raw);
+    return snapshot?._version ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/ide/src/lib/store/__tests__/VersionedPersistence.test.ts
+++ b/ide/src/lib/store/__tests__/VersionedPersistence.test.ts
@@ -1,0 +1,324 @@
+/**
+ * src/lib/store/__tests__/VersionedPersistence.test.ts
+ * Unit tests for the versioned state serialization engine — Issue #648
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  migrateState,
+  wrapSnapshot,
+  parseSnapshot,
+  createVersionedStorage,
+  MigrationBuilder,
+  VersionedPersistenceError,
+  peekStoredVersion,
+  type MigrationMap,
+  type StorageBackend,
+} from "../VersionedPersistence";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// In-memory storage backend for tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeMemoryStorage(): StorageBackend & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => { store.set(k, v); },
+    removeItem: (k) => { store.delete(k); },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// wrapSnapshot
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("wrapSnapshot", () => {
+  it("wraps state in a versioned envelope", () => {
+    const snap = wrapSnapshot({ foo: "bar" }, 3);
+    expect(snap._version).toBe(3);
+    expect(snap.state).toEqual({ foo: "bar" });
+  });
+
+  it("works with primitive state values", () => {
+    expect(wrapSnapshot(42, 1)._version).toBe(1);
+    expect(wrapSnapshot(null, 0).state).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseSnapshot
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseSnapshot", () => {
+  it("parses a valid versioned JSON string", () => {
+    const json = JSON.stringify({ _version: 2, state: { x: 1 } });
+    const snap = parseSnapshot(json);
+    expect(snap?._version).toBe(2);
+    expect((snap?.state as { x: number }).x).toBe(1);
+  });
+
+  it("returns null for null input", () => {
+    expect(parseSnapshot(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSnapshot("")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseSnapshot("not json")).toBeNull();
+  });
+
+  it("returns null when _version is missing", () => {
+    expect(parseSnapshot(JSON.stringify({ state: {} }))).toBeNull();
+  });
+
+  it("returns null when state is missing", () => {
+    expect(parseSnapshot(JSON.stringify({ _version: 1 }))).toBeNull();
+  });
+
+  it("returns null when _version is not a number", () => {
+    expect(parseSnapshot(JSON.stringify({ _version: "v1", state: {} }))).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// migrateState
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("migrateState", () => {
+  const migrations: MigrationMap = {
+    2: (s: unknown) => ({ ...(s as object), b: "added-in-v2" }),
+    3: (s: unknown) => ({ ...(s as object), c: "added-in-v3" }),
+  };
+
+  it("returns state unchanged when already at target version", () => {
+    const result = migrateState({ a: 1 }, 3, 3, migrations);
+    expect(result.stepsApplied).toBe(0);
+    expect(result.state).toEqual({ a: 1 });
+  });
+
+  it("applies a single migration step", () => {
+    const result = migrateState({ a: 1 }, 1, 2, migrations);
+    expect(result.stepsApplied).toBe(1);
+    expect((result.state as Record<string, unknown>).b).toBe("added-in-v2");
+  });
+
+  it("chains multiple migration steps in order", () => {
+    const result = migrateState({ a: 1 }, 1, 3, migrations);
+    expect(result.stepsApplied).toBe(2);
+    const s = result.state as Record<string, unknown>;
+    expect(s.b).toBe("added-in-v2");
+    expect(s.c).toBe("added-in-v3");
+  });
+
+  it("throws FUTURE_VERSION if stored version > target", () => {
+    expect(() => migrateState({}, 5, 3, migrations)).toThrow(VersionedPersistenceError);
+    try {
+      migrateState({}, 5, 3, migrations);
+    } catch (e) {
+      expect((e as VersionedPersistenceError).code).toBe("FUTURE_VERSION");
+    }
+  });
+
+  it("throws MISSING_MIGRATION if a step is absent", () => {
+    const partial: MigrationMap = { 2: migrations[2] }; // missing v3
+    expect(() => migrateState({}, 1, 3, partial)).toThrow(VersionedPersistenceError);
+    try {
+      migrateState({}, 1, 3, partial);
+    } catch (e) {
+      expect((e as VersionedPersistenceError).code).toBe("MISSING_MIGRATION");
+    }
+  });
+
+  it("sets the correct final version", () => {
+    const result = migrateState({}, 1, 3, migrations);
+    expect(result.version).toBe(3);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createVersionedStorage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createVersionedStorage", () => {
+  const migrations: MigrationMap = {
+    2: (s: unknown) => ({ ...(s as object), migrated: true }),
+  };
+
+  it("getItem returns null when storage is empty", async () => {
+    const mem = makeMemoryStorage();
+    const storage = createVersionedStorage(() => mem, 2, migrations);
+    const result = await storage.getItem("key");
+    expect(result).toBeNull();
+  });
+
+  it("setItem writes a versioned envelope", async () => {
+    const mem = makeMemoryStorage();
+    const storage = createVersionedStorage(() => mem, 2, migrations);
+    await storage.setItem("key", { state: { x: 1 } });
+    const raw = JSON.parse(mem.store.get("key")!) as { _version: number; state: unknown };
+    expect(raw._version).toBe(2);
+    expect((raw.state as { x: number }).x).toBe(1);
+  });
+
+  it("getItem retrieves and returns stored state at current version", async () => {
+    const mem = makeMemoryStorage();
+    const storage = createVersionedStorage<{ x: number }>(() => mem, 2, migrations);
+    await storage.setItem("key", { state: { x: 99 } });
+    const result = await storage.getItem("key");
+    expect(result?.state.x).toBe(99);
+  });
+
+  it("getItem migrates state from older version", async () => {
+    const mem = makeMemoryStorage();
+    // Write v1 data directly
+    mem.store.set("key", JSON.stringify({ _version: 1, state: { original: true } }));
+    const onMigrate = vi.fn();
+    const storage = createVersionedStorage(() => mem, 2, migrations, { onMigrate });
+    const result = await storage.getItem("key");
+    expect((result?.state as Record<string, unknown>).migrated).toBe(true);
+    expect(onMigrate).toHaveBeenCalledWith(1, 2, "key");
+  });
+
+  it("persists migrated state back to storage so re-hydration skips migration", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", JSON.stringify({ _version: 1, state: { x: 5 } }));
+    const storage = createVersionedStorage(() => mem, 2, migrations);
+    await storage.getItem("key");
+    const after = JSON.parse(mem.store.get("key")!) as { _version: number; _migratedAt: string };
+    expect(after._version).toBe(2);
+    expect(after._migratedAt).toBeTruthy();
+  });
+
+  it("handles legacy unversioned payloads (treated as v0)", async () => {
+    const mem = makeMemoryStorage();
+    const legacyMigrations: MigrationMap = {
+      1: (s) => ({ ...(s as object), upgraded: true }),
+    };
+    // Write raw JSON with no _version field (pre-versioning data)
+    mem.store.set("key", JSON.stringify({ state: { legacy: true } }));
+    const storage = createVersionedStorage(() => mem, 1, legacyMigrations);
+    const result = await storage.getItem("key");
+    // The whole legacy blob is treated as v0 state and upgraded to v1
+    expect((result?.state as Record<string, unknown>).upgraded).toBe(true);
+  });
+
+  it("calls onCorrupt and returns null for truly corrupt JSON", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", "{ this is not json");
+    const onCorrupt = vi.fn();
+    const storage = createVersionedStorage(() => mem, 2, {}, { onCorrupt });
+    const result = await storage.getItem("key");
+    expect(result).toBeNull();
+    expect(onCorrupt).toHaveBeenCalled();
+  });
+
+  it("calls onCorrupt and returns null when migration is missing", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", JSON.stringify({ _version: 1, state: {} }));
+    const onCorrupt = vi.fn();
+    // No migrations provided — cannot upgrade v1 → v3
+    const storage = createVersionedStorage(() => mem, 3, {}, { onCorrupt });
+    const result = await storage.getItem("key");
+    expect(result).toBeNull();
+    expect(onCorrupt).toHaveBeenCalled();
+  });
+
+  it("removeItem deletes the key from storage", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", "data");
+    const storage = createVersionedStorage(() => mem, 1, {});
+    await storage.removeItem("key");
+    expect(mem.store.has("key")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MigrationBuilder
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("MigrationBuilder", () => {
+  it("builds a MigrationMap from chained add() calls", () => {
+    const map = new MigrationBuilder()
+      .add(2, (s) => ({ ...(s as object), b: 2 }))
+      .add(3, (s) => ({ ...(s as object), c: 3 }))
+      .build();
+    expect(Object.keys(map)).toHaveLength(2);
+    expect(map[2]).toBeTruthy();
+    expect(map[3]).toBeTruthy();
+  });
+
+  it("migrations are correct functions", () => {
+    const map = new MigrationBuilder()
+      .add(2, (s) => ({ ...(s as object), added: true }))
+      .build();
+    const result = (map[2]({ x: 1 }) as Record<string, unknown>);
+    expect(result.added).toBe(true);
+    expect(result.x).toBe(1);
+  });
+
+  it("chains work end-to-end with migrateState", () => {
+    const map = new MigrationBuilder()
+      .add(2, (s) => ({ ...(s as object), v2: true }))
+      .add(3, (s) => ({ ...(s as object), v3: true }))
+      .build();
+    const result = migrateState({}, 1, 3, map);
+    const st = result.state as Record<string, unknown>;
+    expect(st.v2).toBe(true);
+    expect(st.v3).toBe(true);
+  });
+
+  it("throws if a duplicate version is added", () => {
+    const builder = new MigrationBuilder().add(2, (s) => s);
+    expect(() => builder.add(2, (s) => s)).toThrow(VersionedPersistenceError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// peekStoredVersion
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("peekStoredVersion", () => {
+  it("returns the stored version number", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", JSON.stringify({ _version: 4, state: {} }));
+    const v = await peekStoredVersion(mem, "key");
+    expect(v).toBe(4);
+  });
+
+  it("returns null when the key does not exist", async () => {
+    const mem = makeMemoryStorage();
+    const v = await peekStoredVersion(mem, "missing");
+    expect(v).toBeNull();
+  });
+
+  it("returns null for unversioned data", async () => {
+    const mem = makeMemoryStorage();
+    mem.store.set("key", JSON.stringify({ state: {} }));
+    const v = await peekStoredVersion(mem, "key");
+    expect(v).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VersionedPersistenceError
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("VersionedPersistenceError", () => {
+  it("has correct name and code", () => {
+    const err = new VersionedPersistenceError("test", "CORRUPT_DATA");
+    expect(err.name).toBe("VersionedPersistenceError");
+    expect(err.code).toBe("CORRUPT_DATA");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it("all error codes are valid", () => {
+    const codes = ["FUTURE_VERSION", "MISSING_MIGRATION", "CORRUPT_DATA", "STORAGE_ERROR"] as const;
+    for (const code of codes) {
+      expect(new VersionedPersistenceError("msg", code).code).toBe(code);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Closes #648  — Scalable State Serialization

## Deliverable
`src/lib/store/VersionedPersistence.ts`

## What's in this PR

**Version tagging** — every snapshot written to storage carries a `_version` field. Any read that finds a mismatch automatically triggers migration.

**Migration engine (`migrateState`)** — declarative, one-step-at-a-time chain. Adding a v5 migration never requires touching v3/v4. Throws typed errors for `FUTURE_VERSION` (app was downgraded) and `MISSING_MIGRATION` (step is missing).

**Zustand drop-in (`createVersionedStorage`)** — replaces `createJSONStorage(...)` in any `persist()` call. Handles: migration on hydration, writing back migrated state immediately (fast re-hydration), legacy unversioned payloads (treated as v0), corrupt recovery via `onCorrupt` callback.

**`MigrationBuilder` DSL** — fluent chained API for clean migration definitions.

**`peekStoredVersion`** — inspect version from storage without hydrating.

**`VersionedPersistenceError`** — typed codes: `FUTURE_VERSION | MISSING_MIGRATION | CORRUPT_DATA | STORAGE_ERROR`

## Verified Terminal Output
Tests 33 passed (33)

## Acceptance Criteria
- [x] Versioned state snapshots
- [x] Automated migration for older state versions