### PR TITLE
feat: advanced fee strategies, sponsorship policy, delegation store, and protocol matrix

### DIFF
--- a/ide/src/config/ProtocolMatrix.ts
+++ b/ide/src/config/ProtocolMatrix.ts
@@ -1,0 +1,253 @@
+export type ProtocolVersion = 20 | 21 | 22 | 23;
+
+export type OperationTag =
+  | "invokeHostFunction"
+  | "uploadContractWasm"
+  | "createContract"
+  | "extendFootprintTtl"
+  | "restoreFootprint"
+  | "bumpSequence"
+  | "claimableBalance"
+  | "liquidityPool"
+  | "setOptions"
+  | "payment"
+  | "pathPayment"
+  | "manageSellOffer"
+  | "manageBuyOffer"
+  | "changeTrust"
+  | "accountMerge"
+  | "manageData";
+
+export interface OperationSpec {
+  tag: OperationTag;
+  supported: boolean;
+  deprecated?: boolean;
+  deprecatedSince?: ProtocolVersion;
+  removedIn?: ProtocolVersion;
+  notes?: string;
+}
+
+export interface SimulationRule {
+  /** Minimum ledger entries allowed in a transaction footprint */
+  minFootprintEntries: number;
+  /** Maximum ledger entries allowed in a transaction footprint */
+  maxFootprintEntries: number;
+  /** Maximum instructions per transaction */
+  maxInstructions: number;
+  /** Maximum read bytes */
+  maxReadBytes: number;
+  /** Maximum write bytes */
+  maxWriteBytes: number;
+  /** Base fee in stroops */
+  baseFee: number;
+  /** Resource fee per instruction (in stroops) */
+  feePerInstruction: number;
+}
+
+export interface ProtocolSpec {
+  version: ProtocolVersion;
+  label: string;
+  releaseDate: string;
+  sorobanSupported: boolean;
+  operations: OperationSpec[];
+  simulationRules: SimulationRule;
+  deprecatedFeatures: string[];
+  breakingChanges: string[];
+}
+
+export const SIMULATION_RULES: Record<ProtocolVersion, SimulationRule> = {
+  20: {
+    minFootprintEntries: 0,
+    maxFootprintEntries: 40,
+    maxInstructions: 100_000_000,
+    maxReadBytes: 200_000,
+    maxWriteBytes: 65_536,
+    baseFee: 100,
+    feePerInstruction: 25,
+  },
+  21: {
+    minFootprintEntries: 0,
+    maxFootprintEntries: 64,
+    maxInstructions: 100_000_000,
+    maxReadBytes: 200_000,
+    maxWriteBytes: 65_536,
+    baseFee: 100,
+    feePerInstruction: 25,
+  },
+  22: {
+    minFootprintEntries: 0,
+    maxFootprintEntries: 100,
+    maxInstructions: 150_000_000,
+    maxReadBytes: 300_000,
+    maxWriteBytes: 65_536,
+    baseFee: 100,
+    feePerInstruction: 20,
+  },
+  23: {
+    minFootprintEntries: 0,
+    maxFootprintEntries: 128,
+    maxInstructions: 200_000_000,
+    maxReadBytes: 512_000,
+    maxWriteBytes: 131_072,
+    baseFee: 100,
+    feePerInstruction: 15,
+  },
+};
+
+export const PROTOCOL_MATRIX: Record<ProtocolVersion, ProtocolSpec> = {
+  20: {
+    version: 20,
+    label: "Protocol 20 (Soroban Launch)",
+    releaseDate: "2023-09-20",
+    sorobanSupported: true,
+    simulationRules: SIMULATION_RULES[20],
+    operations: [
+      { tag: "invokeHostFunction", supported: true },
+      { tag: "uploadContractWasm", supported: true },
+      { tag: "createContract", supported: true },
+      { tag: "extendFootprintTtl", supported: true },
+      { tag: "restoreFootprint", supported: true },
+      { tag: "bumpSequence", supported: true, deprecated: true, deprecatedSince: 20, notes: "Prefer sequence management via auth" },
+      { tag: "claimableBalance", supported: true },
+      { tag: "liquidityPool", supported: true },
+      { tag: "setOptions", supported: true },
+      { tag: "payment", supported: true },
+      { tag: "pathPayment", supported: true },
+      { tag: "manageSellOffer", supported: true },
+      { tag: "manageBuyOffer", supported: true },
+      { tag: "changeTrust", supported: true },
+      { tag: "accountMerge", supported: true },
+      { tag: "manageData", supported: true },
+    ],
+    deprecatedFeatures: ["bumpSequence — prefer auth-based sequence management"],
+    breakingChanges: [],
+  },
+  21: {
+    version: 21,
+    label: "Protocol 21",
+    releaseDate: "2024-06-01",
+    sorobanSupported: true,
+    simulationRules: SIMULATION_RULES[21],
+    operations: [
+      { tag: "invokeHostFunction", supported: true },
+      { tag: "uploadContractWasm", supported: true },
+      { tag: "createContract", supported: true },
+      { tag: "extendFootprintTtl", supported: true },
+      { tag: "restoreFootprint", supported: true },
+      { tag: "bumpSequence", supported: true, deprecated: true, deprecatedSince: 20 },
+      { tag: "claimableBalance", supported: true },
+      { tag: "liquidityPool", supported: true },
+      { tag: "setOptions", supported: true },
+      { tag: "payment", supported: true },
+      { tag: "pathPayment", supported: true },
+      { tag: "manageSellOffer", supported: true },
+      { tag: "manageBuyOffer", supported: true },
+      { tag: "changeTrust", supported: true },
+      { tag: "accountMerge", supported: true },
+      { tag: "manageData", supported: true },
+    ],
+    deprecatedFeatures: ["bumpSequence — removed in a future protocol"],
+    breakingChanges: ["Footprint entry limit increased to 64"],
+  },
+  22: {
+    version: 22,
+    label: "Protocol 22",
+    releaseDate: "2025-01-01",
+    sorobanSupported: true,
+    simulationRules: SIMULATION_RULES[22],
+    operations: [
+      { tag: "invokeHostFunction", supported: true },
+      { tag: "uploadContractWasm", supported: true },
+      { tag: "createContract", supported: true },
+      { tag: "extendFootprintTtl", supported: true },
+      { tag: "restoreFootprint", supported: true },
+      { tag: "bumpSequence", supported: false, deprecated: true, deprecatedSince: 20, removedIn: 22, notes: "Removed in Protocol 22" },
+      { tag: "claimableBalance", supported: true },
+      { tag: "liquidityPool", supported: true },
+      { tag: "setOptions", supported: true },
+      { tag: "payment", supported: true },
+      { tag: "pathPayment", supported: true },
+      { tag: "manageSellOffer", supported: true },
+      { tag: "manageBuyOffer", supported: true },
+      { tag: "changeTrust", supported: true },
+      { tag: "accountMerge", supported: true },
+      { tag: "manageData", supported: true },
+    ],
+    deprecatedFeatures: [],
+    breakingChanges: [
+      "bumpSequence operation removed",
+      "Instruction limit raised to 150M",
+      "feePerInstruction reduced to 20 stroops",
+    ],
+  },
+  23: {
+    version: 23,
+    label: "Protocol 23 (Upcoming)",
+    releaseDate: "2025-12-01",
+    sorobanSupported: true,
+    simulationRules: SIMULATION_RULES[23],
+    operations: [
+      { tag: "invokeHostFunction", supported: true },
+      { tag: "uploadContractWasm", supported: true },
+      { tag: "createContract", supported: true },
+      { tag: "extendFootprintTtl", supported: true },
+      { tag: "restoreFootprint", supported: true },
+      { tag: "bumpSequence", supported: false, deprecated: true, removedIn: 22 },
+      { tag: "claimableBalance", supported: true },
+      { tag: "liquidityPool", supported: true },
+      { tag: "setOptions", supported: true },
+      { tag: "payment", supported: true },
+      { tag: "pathPayment", supported: true },
+      { tag: "manageSellOffer", supported: true },
+      { tag: "manageBuyOffer", supported: true },
+      { tag: "changeTrust", supported: true },
+      { tag: "accountMerge", supported: true },
+      { tag: "manageData", supported: true },
+    ],
+    deprecatedFeatures: [],
+    breakingChanges: [
+      "Instruction limit raised to 200M",
+      "Write byte limit doubled to 128 KiB",
+      "feePerInstruction reduced to 15 stroops",
+    ],
+  },
+};
+
+export const SUPPORTED_PROTOCOL_VERSIONS = Object.keys(PROTOCOL_MATRIX).map(Number) as ProtocolVersion[];
+export const LATEST_PROTOCOL_VERSION: ProtocolVersion = 22;
+export const UPCOMING_PROTOCOL_VERSION: ProtocolVersion = 23;
+
+export function getProtocolSpec(version: ProtocolVersion): ProtocolSpec {
+  return PROTOCOL_MATRIX[version];
+}
+
+export function getDeprecationWarnings(version: ProtocolVersion, usedOperations: string[]): string[] {
+  const spec = PROTOCOL_MATRIX[version];
+  const warnings: string[] = [];
+
+  for (const opTag of usedOperations) {
+    const opSpec = spec.operations.find((o) => o.tag === opTag);
+    if (!opSpec) continue;
+    if (!opSpec.supported) {
+      warnings.push(`Operation "${opTag}" is NOT supported in Protocol ${version}.${opSpec.notes ? ` ${opSpec.notes}` : ""}`);
+    } else if (opSpec.deprecated) {
+      warnings.push(
+        `Operation "${opTag}" is deprecated since Protocol ${opSpec.deprecatedSince ?? version}` +
+          (opSpec.removedIn ? ` and will be removed in Protocol ${opSpec.removedIn}` : "") +
+          (opSpec.notes ? `. ${opSpec.notes}` : "")
+      );
+    }
+  }
+
+  return warnings;
+}
+
+export function isOperationSupported(version: ProtocolVersion, tag: OperationTag): boolean {
+  const spec = PROTOCOL_MATRIX[version];
+  const op = spec.operations.find((o) => o.tag === tag);
+  return op?.supported ?? false;
+}
+
+export function getSimulationRules(version: ProtocolVersion): SimulationRule {
+  return SIMULATION_RULES[version];
+}

--- a/ide/src/lib/identity/DelegationStore.ts
+++ b/ide/src/lib/identity/DelegationStore.ts
@@ -1,0 +1,209 @@
+import { get as idbGet, set as idbSet } from "idb-keyval";
+
+export interface DelegationEntry {
+  /** The sub-account (delegate) public key that is being granted sponsorship rights */
+  delegatePublicKey: string;
+  /** The sponsor's public key that will pay fees on behalf of the delegate */
+  sponsorPublicKey: string;
+  /** Human-readable label for this delegation */
+  label: string;
+  /** Timestamp (ISO 8601) when this delegation was created */
+  createdAt: string;
+  /** Optional expiry (ISO 8601); undefined means indefinite */
+  expiresAt?: string;
+  /** Whether this delegation is currently active */
+  active: boolean;
+}
+
+export interface DelegationAuditEntry {
+  id: string;
+  delegatePublicKey: string;
+  sponsorPublicKey: string;
+  action: "sponsored" | "revoked" | "expired";
+  timestamp: string;
+  details?: string;
+}
+
+interface DelegationStoreState {
+  delegations: DelegationEntry[];
+  auditLog: DelegationAuditEntry[];
+}
+
+const STORAGE_KEY = "stellar_delegation_store";
+const AUDIT_STORAGE_KEY = "stellar_delegation_audit";
+const MAX_AUDIT_ENTRIES = 500;
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export class DelegationStore {
+  private static instance: DelegationStore;
+  private state: DelegationStoreState = { delegations: [], auditLog: [] };
+
+  private constructor() {}
+
+  static getInstance(): DelegationStore {
+    if (!DelegationStore.instance) {
+      DelegationStore.instance = new DelegationStore();
+    }
+    return DelegationStore.instance;
+  }
+
+  async load(): Promise<void> {
+    const [delegations, auditLog] = await Promise.all([
+      idbGet<DelegationEntry[]>(STORAGE_KEY),
+      idbGet<DelegationAuditEntry[]>(AUDIT_STORAGE_KEY),
+    ]);
+    this.state = {
+      delegations: delegations ?? [],
+      auditLog: auditLog ?? [],
+    };
+  }
+
+  private async persist(): Promise<void> {
+    await Promise.all([
+      idbSet(STORAGE_KEY, this.state.delegations),
+      idbSet(AUDIT_STORAGE_KEY, this.state.auditLog),
+    ]);
+  }
+
+  private addAuditEntry(entry: Omit<DelegationAuditEntry, "id" | "timestamp">): void {
+    const newEntry: DelegationAuditEntry = {
+      ...entry,
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+    };
+    this.state.auditLog = [newEntry, ...this.state.auditLog].slice(0, MAX_AUDIT_ENTRIES);
+  }
+
+  getDelegations(): DelegationEntry[] {
+    return [...this.state.delegations];
+  }
+
+  getActiveDelegations(): DelegationEntry[] {
+    const now = new Date().toISOString();
+    return this.state.delegations.filter(
+      (d) => d.active && (!d.expiresAt || d.expiresAt > now)
+    );
+  }
+
+  /** Returns the sponsor key for a given delegate, or null if no active delegation exists */
+  getSponsorForDelegate(delegatePublicKey: string): string | null {
+    const delegation = this.getActiveDelegations().find(
+      (d) => d.delegatePublicKey === delegatePublicKey
+    );
+    return delegation?.sponsorPublicKey ?? null;
+  }
+
+  /** Returns all delegates currently assigned to a sponsor */
+  getDelegatesForSponsor(sponsorPublicKey: string): DelegationEntry[] {
+    return this.getActiveDelegations().filter(
+      (d) => d.sponsorPublicKey === sponsorPublicKey
+    );
+  }
+
+  async addDelegation(entry: Omit<DelegationEntry, "createdAt" | "active">): Promise<DelegationEntry> {
+    const existing = this.state.delegations.find(
+      (d) => d.delegatePublicKey === entry.delegatePublicKey && d.sponsorPublicKey === entry.sponsorPublicKey
+    );
+    if (existing) {
+      throw new Error(
+        `Delegation from ${entry.sponsorPublicKey} to ${entry.delegatePublicKey} already exists`
+      );
+    }
+
+    const newEntry: DelegationEntry = {
+      ...entry,
+      createdAt: new Date().toISOString(),
+      active: true,
+    };
+    this.state.delegations = [...this.state.delegations, newEntry];
+
+    this.addAuditEntry({
+      delegatePublicKey: entry.delegatePublicKey,
+      sponsorPublicKey: entry.sponsorPublicKey,
+      action: "sponsored",
+      details: `Delegation created: ${entry.label}`,
+    });
+
+    await this.persist();
+    return newEntry;
+  }
+
+  async revokeDelegation(delegatePublicKey: string, sponsorPublicKey: string): Promise<void> {
+    const idx = this.state.delegations.findIndex(
+      (d) => d.delegatePublicKey === delegatePublicKey && d.sponsorPublicKey === sponsorPublicKey
+    );
+    if (idx === -1) {
+      throw new Error("Delegation not found");
+    }
+
+    this.state.delegations = this.state.delegations.map((d, i) =>
+      i === idx ? { ...d, active: false } : d
+    );
+
+    this.addAuditEntry({
+      delegatePublicKey,
+      sponsorPublicKey,
+      action: "revoked",
+      details: "Delegation manually revoked",
+    });
+
+    await this.persist();
+  }
+
+  async removeDelegation(delegatePublicKey: string, sponsorPublicKey: string): Promise<void> {
+    await this.revokeDelegation(delegatePublicKey, sponsorPublicKey);
+    this.state.delegations = this.state.delegations.filter(
+      (d) => !(d.delegatePublicKey === delegatePublicKey && d.sponsorPublicKey === sponsorPublicKey)
+    );
+    await this.persist();
+  }
+
+  /** Mark expired delegations and write audit entries */
+  async pruneExpired(): Promise<number> {
+    const now = new Date().toISOString();
+    let pruned = 0;
+    this.state.delegations = this.state.delegations.map((d) => {
+      if (d.active && d.expiresAt && d.expiresAt <= now) {
+        this.addAuditEntry({
+          delegatePublicKey: d.delegatePublicKey,
+          sponsorPublicKey: d.sponsorPublicKey,
+          action: "expired",
+          details: `Delegation expired at ${d.expiresAt}`,
+        });
+        pruned++;
+        return { ...d, active: false };
+      }
+      return d;
+    });
+    if (pruned > 0) await this.persist();
+    return pruned;
+  }
+
+  /** Record that a delegate used a sponsor for a transaction */
+  async recordUsage(delegatePublicKey: string, sponsorPublicKey: string, details?: string): Promise<void> {
+    this.addAuditEntry({
+      delegatePublicKey,
+      sponsorPublicKey,
+      action: "sponsored",
+      details,
+    });
+    await idbSet(AUDIT_STORAGE_KEY, this.state.auditLog);
+  }
+
+  getAuditLog(filter?: { delegatePublicKey?: string; sponsorPublicKey?: string }): DelegationAuditEntry[] {
+    if (!filter) return [...this.state.auditLog];
+    return this.state.auditLog.filter((entry) => {
+      if (filter.delegatePublicKey && entry.delegatePublicKey !== filter.delegatePublicKey) return false;
+      if (filter.sponsorPublicKey && entry.sponsorPublicKey !== filter.sponsorPublicKey) return false;
+      return true;
+    });
+  }
+
+  clearAuditLog(): void {
+    this.state.auditLog = [];
+    idbSet(AUDIT_STORAGE_KEY, []);
+  }
+}

--- a/ide/src/lib/stellar/FeeEstimator.ts
+++ b/ide/src/lib/stellar/FeeEstimator.ts
@@ -1,0 +1,147 @@
+import { NETWORK_CONFIG, NetworkKey } from "@/lib/networkConfig";
+import { FeeDataService, FeeStats } from "@/lib/feeDataService";
+
+export type FeePriority = "low" | "medium" | "high";
+
+export interface CongestionLevel {
+  level: "low" | "moderate" | "high" | "critical";
+  capacityUsage: number;
+  label: string;
+  color: string;
+}
+
+export interface FeeEstimate {
+  priority: FeePriority;
+  fee: number;
+  label: string;
+  description: string;
+  estimatedWaitLedgers: number;
+}
+
+export interface FeeEstimatorResult {
+  congestion: CongestionLevel;
+  estimates: Record<FeePriority, FeeEstimate>;
+  baseFee: number;
+  fetchedAt: string;
+  network: NetworkKey;
+}
+
+const PRIORITY_CONFIG: Record<FeePriority, { label: string; description: string; multiplier: number; waitLedgers: number }> = {
+  low: {
+    label: "Low",
+    description: "Best effort — may be delayed during congestion",
+    multiplier: 1.0,
+    waitLedgers: 10,
+  },
+  medium: {
+    label: "Medium",
+    description: "Balanced cost and inclusion speed",
+    multiplier: 1.5,
+    waitLedgers: 3,
+  },
+  high: {
+    label: "High",
+    description: "Priority inclusion — recommended during high traffic",
+    multiplier: 2.5,
+    waitLedgers: 1,
+  },
+};
+
+function parseCongestion(stats: FeeStats): CongestionLevel {
+  const usage = parseFloat(stats.ledger_capacity_usage);
+
+  if (usage < 0.3) {
+    return { level: "low", capacityUsage: usage, label: "Low Congestion", color: "#10b981" };
+  }
+  if (usage < 0.6) {
+    return { level: "moderate", capacityUsage: usage, label: "Moderate Congestion", color: "#f59e0b" };
+  }
+  if (usage < 0.85) {
+    return { level: "high", capacityUsage: usage, label: "High Congestion", color: "#ef4444" };
+  }
+  return { level: "critical", capacityUsage: usage, label: "Critical Congestion", color: "#dc2626" };
+}
+
+function deriveBaseFee(stats: FeeStats): number {
+  // Use p50 of fee_charged as the realistic baseline
+  const p50 = parseInt(stats.fee_charged.p50, 10);
+  const lastBase = parseInt(stats.last_ledger_base_fee, 10);
+  return Math.max(p50, lastBase, 100);
+}
+
+function buildEstimates(baseFee: number, congestion: CongestionLevel): Record<FeePriority, FeeEstimate> {
+  const congestionBoost = congestion.level === "critical" ? 1.5 : congestion.level === "high" ? 1.2 : 1.0;
+
+  return (["low", "medium", "high"] as FeePriority[]).reduce((acc, priority) => {
+    const cfg = PRIORITY_CONFIG[priority];
+    const fee = Math.ceil(baseFee * cfg.multiplier * congestionBoost);
+    acc[priority] = {
+      priority,
+      fee,
+      label: cfg.label,
+      description: cfg.description,
+      estimatedWaitLedgers: congestion.level === "critical" && priority === "low"
+        ? cfg.waitLedgers * 5
+        : cfg.waitLedgers,
+    };
+    return acc;
+  }, {} as Record<FeePriority, FeeEstimate>);
+}
+
+export class FeeEstimator {
+  private static instance: FeeEstimator;
+  private feeDataService: FeeDataService;
+  private cache: Map<NetworkKey, { result: FeeEstimatorResult; timestamp: number }> = new Map();
+  private readonly CACHE_TTL_MS = 15_000; // 15 seconds — fresher than feeDataService
+
+  private constructor() {
+    this.feeDataService = FeeDataService.getInstance();
+  }
+
+  static getInstance(): FeeEstimator {
+    if (!FeeEstimator.instance) {
+      FeeEstimator.instance = new FeeEstimator();
+    }
+    return FeeEstimator.instance;
+  }
+
+  async estimate(network: NetworkKey): Promise<FeeEstimatorResult> {
+    const cached = this.cache.get(network);
+    if (cached && Date.now() - cached.timestamp < this.CACHE_TTL_MS) {
+      return cached.result;
+    }
+
+    const stats = await this.feeDataService.getCurrentFeeStats(network);
+    const congestion = parseCongestion(stats);
+    const baseFee = deriveBaseFee(stats);
+    const estimates = buildEstimates(baseFee, congestion);
+
+    const result: FeeEstimatorResult = {
+      congestion,
+      estimates,
+      baseFee,
+      fetchedAt: new Date().toISOString(),
+      network,
+    };
+
+    this.cache.set(network, { result, timestamp: Date.now() });
+    return result;
+  }
+
+  getFeeForPriority(result: FeeEstimatorResult, priority: FeePriority): number {
+    return result.estimates[priority].fee;
+  }
+
+  invalidateCache(network?: NetworkKey): void {
+    if (network) {
+      this.cache.delete(network);
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  /** Returns Horizon fee_stats URL for the given network */
+  static getHorizonFeeStatsUrl(network: NetworkKey): string {
+    return `${NETWORK_CONFIG[network].horizonUrl}/fee_stats`;
+  }
+}

--- a/ide/src/lib/stellar/SponsorshipPolicy.ts
+++ b/ide/src/lib/stellar/SponsorshipPolicy.ts
@@ -1,0 +1,200 @@
+export type OperationType =
+  | "createAccount"
+  | "payment"
+  | "pathPaymentStrictReceive"
+  | "pathPaymentStrictSend"
+  | "manageSellOffer"
+  | "manageBuyOffer"
+  | "createPassiveSellOffer"
+  | "setOptions"
+  | "changeTrust"
+  | "allowTrust"
+  | "accountMerge"
+  | "manageData"
+  | "bumpSequence"
+  | "claimClaimableBalance"
+  | "beginSponsoringFutureReserves"
+  | "endSponsoringFutureReserves"
+  | "revokeSponsorship"
+  | "clawback"
+  | "clawbackClaimableBalance"
+  | "setTrustLineFlags"
+  | "liquidityPoolDeposit"
+  | "liquidityPoolWithdraw"
+  | "invokeHostFunction"
+  | "extendFootprintTtl"
+  | "restoreFootprint";
+
+export type EligibilityStatus = "eligible" | "ineligible" | "conditional";
+
+export interface AssetFilter {
+  assetCode?: string;
+  issuer?: string;
+  assetType?: "native" | "credit_alphanum4" | "credit_alphanum12" | "all";
+}
+
+export interface SponsorshipRule {
+  id: string;
+  name: string;
+  allowedOperations: OperationType[];
+  deniedOperations: OperationType[];
+  assetFilter?: AssetFilter;
+  maxFeePerOperation?: number;
+  enabled: boolean;
+  description?: string;
+}
+
+export interface PolicyViolation {
+  operationType: OperationType;
+  reason: string;
+  ruleId?: string;
+}
+
+export interface EligibilityResult {
+  status: EligibilityStatus;
+  eligible: OperationType[];
+  ineligible: PolicyViolation[];
+  conditional: { operation: OperationType; condition: string }[];
+  badge: { label: string; color: string };
+  policyName: string;
+}
+
+const STATUS_BADGE: Record<EligibilityStatus, { label: string; color: string }> = {
+  eligible: { label: "Sponsored", color: "#10b981" },
+  ineligible: { label: "Not Eligible", color: "#ef4444" },
+  conditional: { label: "Conditional", color: "#f59e0b" },
+};
+
+export const DEFAULT_POLICY: SponsorshipRule = {
+  id: "default",
+  name: "Default Testnet Policy",
+  allowedOperations: [
+    "createAccount",
+    "invokeHostFunction",
+    "extendFootprintTtl",
+    "restoreFootprint",
+    "changeTrust",
+    "payment",
+  ],
+  deniedOperations: ["accountMerge", "clawback", "clawbackClaimableBalance"],
+  assetFilter: { assetType: "all" },
+  maxFeePerOperation: 10_000_000, // 1 XLM in stroops
+  enabled: true,
+  description: "Allows common Soroban development operations",
+};
+
+export class SponsorshipPolicy {
+  private rules: SponsorshipRule[];
+
+  constructor(rules: SponsorshipRule[] = [DEFAULT_POLICY]) {
+    this.rules = rules;
+  }
+
+  addRule(rule: SponsorshipRule): void {
+    const existing = this.rules.findIndex((r) => r.id === rule.id);
+    if (existing !== -1) {
+      this.rules[existing] = rule;
+    } else {
+      this.rules.push(rule);
+    }
+  }
+
+  removeRule(ruleId: string): void {
+    this.rules = this.rules.filter((r) => r.id !== ruleId);
+  }
+
+  getRules(): SponsorshipRule[] {
+    return [...this.rules];
+  }
+
+  getActiveRules(): SponsorshipRule[] {
+    return this.rules.filter((r) => r.enabled);
+  }
+
+  /** Check a list of operation types against all active rules */
+  checkEligibility(operations: OperationType[], sponsorPublicKey?: string): EligibilityResult {
+    const activeRules = this.getActiveRules();
+    if (activeRules.length === 0) {
+      return {
+        status: "ineligible",
+        eligible: [],
+        ineligible: operations.map((op) => ({ operationType: op, reason: "No active sponsorship rules" })),
+        conditional: [],
+        badge: STATUS_BADGE.ineligible,
+        policyName: "None",
+      };
+    }
+
+    // Merge all active rules: union of allowed, intersection logic for denied
+    const allAllowed = new Set(activeRules.flatMap((r) => r.allowedOperations));
+    const allDenied = new Set(activeRules.flatMap((r) => r.deniedOperations));
+    const policyName = activeRules.map((r) => r.name).join(", ");
+
+    const eligible: OperationType[] = [];
+    const ineligible: PolicyViolation[] = [];
+    const conditional: { operation: OperationType; condition: string }[] = [];
+
+    for (const op of operations) {
+      if (allDenied.has(op)) {
+        const rule = activeRules.find((r) => r.deniedOperations.includes(op));
+        ineligible.push({
+          operationType: op,
+          reason: `Denied by policy: ${rule?.name ?? "unknown"}`,
+          ruleId: rule?.id,
+        });
+      } else if (allAllowed.has(op)) {
+        const maxFeeRule = activeRules.find((r) => r.allowedOperations.includes(op) && r.maxFeePerOperation !== undefined);
+        if (maxFeeRule?.maxFeePerOperation !== undefined) {
+          conditional.push({
+            operation: op,
+            condition: `Fee must not exceed ${maxFeeRule.maxFeePerOperation} stroops`,
+          });
+        } else {
+          eligible.push(op);
+        }
+      } else {
+        ineligible.push({
+          operationType: op,
+          reason: "Operation not explicitly allowed by any active policy",
+        });
+      }
+    }
+
+    let status: EligibilityStatus = "eligible";
+    if (ineligible.length > 0 && eligible.length === 0 && conditional.length === 0) {
+      status = "ineligible";
+    } else if (conditional.length > 0 || (ineligible.length > 0 && eligible.length > 0)) {
+      status = "conditional";
+    }
+
+    return {
+      status,
+      eligible,
+      ineligible,
+      conditional,
+      badge: STATUS_BADGE[status],
+      policyName,
+    };
+  }
+
+  /** Returns a human-readable summary of the active policy for display */
+  getPolicySummary(): string {
+    const active = this.getActiveRules();
+    if (active.length === 0) return "No active sponsorship policies.";
+    return active.map((r) => `[${r.name}] Allows: ${r.allowedOperations.join(", ")}`).join("\n");
+  }
+
+  /** Serialize policy to JSON for persistence */
+  toJSON(): string {
+    return JSON.stringify(this.rules, null, 2);
+  }
+
+  static fromJSON(json: string): SponsorshipPolicy {
+    try {
+      const rules = JSON.parse(json) as SponsorshipRule[];
+      return new SponsorshipPolicy(rules);
+    } catch {
+      return new SponsorshipPolicy();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **#658** — `ide/src/lib/stellar/FeeEstimator.ts`: Real-time congestion detection via Horizon `/fee_stats`, with Low / Medium / High priority fee estimates and 15-second caching. Builds on the existing `FeeDataService`.
- **#659** — `ide/src/lib/stellar/SponsorshipPolicy.ts`: Client-side operation validator against configurable sponsorship rules. Returns per-operation eligibility status with colored badge indicators (`eligible` / `conditional` / `ineligible`).
- **#660** — `ide/src/lib/identity/DelegationStore.ts`: IndexedDB-backed delegation store mapping delegate public keys to sponsor public keys. Includes full audit log (create / revoke / expire / usage), expiry pruning, and multi-identity query helpers.
- **#661** — `ide/src/config/ProtocolMatrix.ts`: Protocol version matrix (v20–v23) with per-version simulation resource limits, operation support flags, deprecation warnings, and a `getDeprecationWarnings()` helper for surfacing breaking changes at runtime.

## Test plan

- [ ] `FeeEstimator.estimate("testnet")` returns a result with `congestion`, `estimates.low/medium/high`, and `baseFee`
- [ ] `SponsorshipPolicy.checkEligibility(["invokeHostFunction"])` returns `status: "eligible"` under the default policy
- [ ] `SponsorshipPolicy.checkEligibility(["accountMerge"])` returns `status: "ineligible"`
- [ ] `DelegationStore.addDelegation(...)` persists to IndexedDB and `getSponsorForDelegate(key)` returns the correct sponsor
- [ ] `DelegationStore.recordUsage(...)` appends an audit entry; `getAuditLog()` reflects it
- [ ] `getDeprecationWarnings(22, ["bumpSequence"])` returns a warning about removal
- [ ] `isOperationSupported(22, "bumpSequence")` returns `false`

closes #658
closes #659
closes #660
closes #661