### PR TITLE
feat: tab sync reconciliation, store partitioning, wallet DI hook, UI theme provider

### DIFF
--- a/ide/src/components/ui/theme-provider.tsx
+++ b/ide/src/components/ui/theme-provider.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+/**
+ * src/components/ui/theme-provider.tsx
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Centralised theme provider for the shared UI component library (Issue #822).
+ *
+ * Wraps next-themes and exposes:
+ *   - <ThemeProvider>  — root wrapper; place once in layout.tsx
+ *   - <ThemeToggle />  — accessible dropdown that switches between all themes
+ *   - useAppTheme()    — hook for reading / setting the current theme
+ *
+ * Supported themes (mapped to CSS class names in globals.css):
+ *   "dark"      — default dark IDE palette
+ *   "light"     — light IDE palette
+ *   "dark-hc"   — dark high-contrast (WCAG AA)
+ *   "light-hc"  — light high-contrast (WCAG AA)
+ *   "system"    — follows OS preference
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+import { cn } from "@/lib/utils";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type AppTheme = "dark" | "light" | "dark-hc" | "light-hc" | "system";
+
+const THEMES: { value: AppTheme; label: string }[] = [
+  { value: "dark",     label: "Dark" },
+  { value: "light",    label: "Light" },
+  { value: "dark-hc",  label: "Dark (High Contrast)" },
+  { value: "light-hc", label: "Light (High Contrast)" },
+  { value: "system",   label: "System" },
+];
+
+// ── ThemeProvider ─────────────────────────────────────────────────────────────
+
+/**
+ * Root theme provider — wrap your root layout once.
+ *
+ * @example
+ * // app/layout.tsx
+ * import { ThemeProvider } from "@/components/ui/theme-provider";
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html suppressHydrationWarning>
+ *       <body>
+ *         <ThemeProvider>{children}</ThemeProvider>
+ *       </body>
+ *     </html>
+ *   );
+ * }
+ */
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      themes={THEMES.map((t) => t.value)}
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}
+
+// ── useAppTheme ───────────────────────────────────────────────────────────────
+
+/**
+ * Hook for reading and setting the current app theme.
+ * Returns `undefined` on the server / before mount to avoid hydration mismatches.
+ */
+export function useAppTheme() {
+  const { theme, setTheme, resolvedTheme, systemTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  return {
+    theme: mounted ? (theme as AppTheme | undefined) : undefined,
+    resolvedTheme: mounted ? (resolvedTheme as AppTheme | undefined) : undefined,
+    systemTheme: mounted ? (systemTheme as AppTheme | undefined) : undefined,
+    setTheme: (t: AppTheme) => setTheme(t),
+    mounted,
+    isDark: mounted && (resolvedTheme === "dark" || resolvedTheme === "dark-hc"),
+    isLight: mounted && (resolvedTheme === "light" || resolvedTheme === "light-hc"),
+    isHighContrast: mounted && (resolvedTheme === "dark-hc" || resolvedTheme === "light-hc"),
+  };
+}
+
+// ── ThemeToggle ───────────────────────────────────────────────────────────────
+
+export interface ThemeToggleProps {
+  /** Additional class names forwarded to the root <select>. */
+  className?: string;
+}
+
+/**
+ * Accessible theme selector dropdown.
+ * Renders a placeholder (visually hidden) until mounted to prevent
+ * server/client hydration mismatches.
+ *
+ * @example
+ * import { ThemeToggle } from "@/components/ui/theme-provider";
+ * <ThemeToggle className="ml-auto" />
+ */
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, setTheme, mounted } = useAppTheme();
+
+  if (!mounted) {
+    return (
+      <select
+        aria-label="Select theme"
+        disabled
+        className={cn(
+          "rounded border border-border bg-background px-2 py-1 text-sm text-foreground opacity-0",
+          className,
+        )}
+      >
+        <option>Theme</option>
+      </select>
+    );
+  }
+
+  return (
+    <select
+      aria-label="Select theme"
+      value={theme ?? "dark"}
+      onChange={(e) => setTheme(e.target.value as AppTheme)}
+      className={cn(
+        "rounded border border-border bg-background px-2 py-1 text-sm text-foreground",
+        "focus:outline-none focus:ring-2 focus:ring-ring",
+        className,
+      )}
+    >
+      {THEMES.map(({ value, label }) => (
+        <option key={value} value={value}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/ide/src/hooks/useWalletAdapter.ts
+++ b/ide/src/hooks/useWalletAdapter.ts
@@ -1,0 +1,205 @@
+"use client";
+
+/**
+ * src/hooks/useWalletAdapter.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * React hook for dependency-injected wallet adapter access (Issue #821).
+ *
+ * Bridges the WalletAdapterRegistry DI container with React state so
+ * components can connect, sign, and disconnect without importing a specific
+ * wallet SDK directly.
+ *
+ * Usage:
+ *   const { adapter, connect, disconnect, publicKey, status, error } =
+ *     useWalletAdapter("freighter");
+ *
+ *   // Or: let the user pick
+ *   const { adapter, connect } = useWalletAdapter(selectedWalletType);
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { useState, useCallback, useEffect } from "react";
+import {
+  WalletAdapterRegistry,
+  WalletAdapterError,
+  type WalletAdapter,
+  type WalletAdapterType,
+  type SignOptions,
+  type ConnectResult,
+} from "@/lib/wallet/BaseAdapter";
+
+// Ensure concrete adapters are registered before first use
+import "@/lib/wallet/FreighterAdapter";
+import "@/lib/wallet/AlbedoAdapter";
+import "@/lib/wallet/HanaAdapter";
+
+export type WalletStatus =
+  | "idle"
+  | "checking"
+  | "connecting"
+  | "connected"
+  | "signing"
+  | "disconnecting"
+  | "error";
+
+export interface UseWalletAdapterReturn {
+  /** The raw adapter instance (null if the type is not registered). */
+  adapter: WalletAdapter | null;
+  /** Current lifecycle status. */
+  status: WalletStatus;
+  /** Connected public key, or null when not connected. */
+  publicKey: string | null;
+  /** Last error from any adapter operation. */
+  error: WalletAdapterError | null;
+  /** Whether the provider extension / popup is available in this browser. */
+  isAvailable: boolean;
+  /** Connect the wallet and store the returned public key. */
+  connect: () => Promise<ConnectResult | null>;
+  /** Sign a transaction XDR and return the signed XDR string. */
+  signTransaction: (xdr: string, options?: SignOptions) => Promise<string | null>;
+  /** Sign a Soroban auth entry XDR. */
+  signAuthEntry: (entryXdr: string, options?: SignOptions) => Promise<string | null>;
+  /** Disconnect and clear local session state. */
+  disconnect: () => Promise<void>;
+  /** Clear the last error without changing status. */
+  clearError: () => void;
+}
+
+export function useWalletAdapter(type: WalletAdapterType): UseWalletAdapterReturn {
+  const [status, setStatus] = useState<WalletStatus>("idle");
+  const [publicKey, setPublicKey] = useState<string | null>(null);
+  const [error, setError] = useState<WalletAdapterError | null>(null);
+  const [isAvailable, setIsAvailable] = useState(false);
+
+  const getAdapter = useCallback((): WalletAdapter | null => {
+    try {
+      return WalletAdapterRegistry.get(type);
+    } catch {
+      return null;
+    }
+  }, [type]);
+
+  // Check availability on mount and when the type changes.
+  useEffect(() => {
+    const adapter = getAdapter();
+    if (!adapter) {
+      setIsAvailable(false);
+      return;
+    }
+    setStatus("checking");
+    void adapter.isAvailable().then((available) => {
+      setIsAvailable(available);
+      setStatus("idle");
+    });
+  }, [type, getAdapter]);
+
+  // Check for an existing session on mount.
+  useEffect(() => {
+    const adapter = getAdapter();
+    if (!adapter) return;
+    void adapter.checkConnection().then((pk) => {
+      if (pk) {
+        setPublicKey(pk);
+        setStatus("connected");
+      }
+    });
+  }, [type, getAdapter]);
+
+  const connect = useCallback(async (): Promise<ConnectResult | null> => {
+    const adapter = getAdapter();
+    if (!adapter) return null;
+    setStatus("connecting");
+    setError(null);
+    try {
+      const result = await adapter.connect();
+      setPublicKey(result.publicKey);
+      setStatus("connected");
+      return result;
+    } catch (err) {
+      const adapterError =
+        err instanceof WalletAdapterError
+          ? err
+          : new WalletAdapterError(type, "CONNECTION_FAILED", String(err), err);
+      setError(adapterError);
+      setStatus("error");
+      return null;
+    }
+  }, [type, getAdapter]);
+
+  const signTransaction = useCallback(
+    async (xdr: string, options?: SignOptions): Promise<string | null> => {
+      const adapter = getAdapter();
+      if (!adapter) return null;
+      setStatus("signing");
+      setError(null);
+      try {
+        const signed = await adapter.signTransaction(xdr, options);
+        setStatus("connected");
+        return signed;
+      } catch (err) {
+        const adapterError =
+          err instanceof WalletAdapterError
+            ? err
+            : new WalletAdapterError(type, "SIGN_FAILED", String(err), err);
+        setError(adapterError);
+        setStatus("error");
+        return null;
+      }
+    },
+    [type, getAdapter],
+  );
+
+  const signAuthEntry = useCallback(
+    async (entryXdr: string, options?: SignOptions): Promise<string | null> => {
+      const adapter = getAdapter();
+      if (!adapter) return null;
+      setStatus("signing");
+      setError(null);
+      try {
+        const signed = await adapter.signAuthEntry(entryXdr, options);
+        setStatus("connected");
+        return signed;
+      } catch (err) {
+        const adapterError =
+          err instanceof WalletAdapterError
+            ? err
+            : new WalletAdapterError(type, "SIGN_FAILED", String(err), err);
+        setError(adapterError);
+        setStatus("error");
+        return null;
+      }
+    },
+    [type, getAdapter],
+  );
+
+  const disconnect = useCallback(async (): Promise<void> => {
+    const adapter = getAdapter();
+    if (!adapter) return;
+    setStatus("disconnecting");
+    setError(null);
+    try {
+      await adapter.disconnect();
+    } finally {
+      setPublicKey(null);
+      setStatus("idle");
+    }
+  }, [getAdapter]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+    if (status === "error") setStatus(publicKey ? "connected" : "idle");
+  }, [status, publicKey]);
+
+  return {
+    adapter: getAdapter(),
+    status,
+    publicKey,
+    error,
+    isAvailable,
+    connect,
+    signTransaction,
+    signAuthEntry,
+    disconnect,
+    clearError,
+  };
+}

--- a/ide/src/store/identityStore.ts
+++ b/ide/src/store/identityStore.ts
@@ -1,0 +1,29 @@
+/**
+ * src/store/identityStore.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Domain-specific Zustand store for identity and keypair management.
+ * Part of the store partitioning initiative (Issue #819).
+ *
+ * Re-exports the canonical `useIdentityStore` under the domain-store naming
+ * convention so consumers can import from either path:
+ *
+ *   import { useIdentityStore } from "@/store/identityStore";
+ *   import { useIdentityStore } from "@/store/useIdentityStore"; // also valid
+ *
+ * Owns:
+ *  • Local keypair vault (AES-GCM encrypted, stored in IndexedDB)
+ *  • Active identity context (web-wallet vs local keypair)
+ *  • Web-wallet public key (set by the adapter layer)
+ *  • XLM balance cache per public key
+ *  • Vault lock / unlock lifecycle
+ *
+ * Zero circular dependencies — this store does not import from networkStore,
+ * fileStore, or uiStore.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+export {
+  useIdentityStore,
+  type Identity,
+  type ActiveContext,
+} from "./useIdentityStore";

--- a/ide/src/store/networkStore.ts
+++ b/ide/src/store/networkStore.ts
@@ -1,0 +1,44 @@
+/**
+ * src/store/networkStore.ts
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Domain-specific Zustand store for all network configuration state.
+ * Part of the store partitioning initiative (Issue #819).
+ *
+ * Re-exports the canonical `useNetworkStore` under the domain-store naming
+ * convention so consumers can import from either path:
+ *
+ *   import { useNetworkStore } from "@/store/networkStore";
+ *   import { useNetworkStore } from "@/store/useNetworkStore"; // also valid
+ *
+ * Owns:
+ *  • Active network selection (testnet | futurenet | mainnet | local | custom)
+ *  • RPC endpoint URL and custom headers
+ *  • Network passphrase and Horizon URL
+ *  • Named custom network profiles
+ *  • Per-network isolated workspace state (deployments, env vars, notes)
+ *
+ * Zero circular dependencies — this store does not import from identityStore,
+ * fileStore, or uiStore.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+export {
+  useNetworkStore,
+  useResolvedRpcUrl,
+  useResolvedPassphrase,
+  useActiveNetwork,
+  useNetworkProfiles,
+  useNetworkValidationError,
+  useResolvedNetworkConfig,
+  useActiveWorkspace,
+  useActiveNetworkContracts,
+  useActiveNetworkEnvVars,
+  useActiveNetworkNotes,
+  useAllNetworkWorkspaces,
+  type ExtendedNetworkKey,
+  type CustomNetworkProfile,
+  type ValidationResult,
+  type NetworkWorkspace,
+  type DeployedContractEntry,
+  type NetworkStoreState,
+} from "./useNetworkStore";

--- a/ide/src/store/useCloudSyncStore.ts
+++ b/ide/src/store/useCloudSyncStore.ts
@@ -61,6 +61,14 @@ interface CloudSyncState {
     openTabs?: TabInfo[],
     activeTabPath?: string[],
   ) => void;
+  /** Debounced 1-second sync triggered whenever the active tab state changes. */
+  scheduleTabSync: (
+    userId: string,
+    files: WorkspaceTextFile[],
+    network: string,
+    openTabs: TabInfo[],
+    activeTabPath: string[],
+  ) => void;
   loadFromCloud: (projectId: string) => Promise<ProjectData | null>;
   applyRemoteTabState: (openTabs: TabInfo[], activeTabPath: string[]) => void;
   resolveConflict: (choice: "local" | "cloud") => void;


### PR DESCRIPTION
Fixes #818
Fixes #819
Fixes #821
Fixes #822

## What changed

- **#818** — `scheduleTabSync` was implemented in `useCloudSyncStore` but missing from the `CloudSyncState` interface declaration, producing a TypeScript error at any call site. Added the full method signature to the interface. The 1-second debounced tab sync path (distinct from the 5-second auto-save) is now correctly typed.

- **#819** — Added `src/store/networkStore.ts` and `src/store/identityStore.ts` as domain-specific entry-point files that re-export all selectors, actions, and types from the existing `useNetworkStore` / `useIdentityStore`. Consumers can now import from the domain path (`@/store/networkStore`) without knowing the internal naming convention. Each store's JSDoc explicitly lists its ownership boundary and confirms zero circular dependencies to any other domain store.

- **#821** — Added `src/hooks/useWalletAdapter.ts`: a React hook that wraps `WalletAdapterRegistry` for component-level dependency injection. Exposes `connect`, `signTransaction`, `signAuthEntry`, `disconnect`, lifecycle `status`, `publicKey`, `error`, and `isAvailable` — all typed. Handles availability checks and existing-session detection on mount. Works with Freighter, Albedo, and Hana via the self-registering adapters.

- **#822** — Added `src/components/ui/theme-provider.tsx` to the shared component library. Exports `<ThemeProvider>` (root wrapper), `useAppTheme()` hook (dark/light/highContrast/system flags), and `<ThemeToggle />` dropdown. Built on next-themes and the existing CSS variable design tokens in `globals.css`. Hydration-safe placeholder prevents SSR flash.

## Why

- **#818**: Missing interface declaration causes `Property 'scheduleTabSync' does not exist` TS errors when callers try to destructure or call the action.
- **#819**: Domain-named entry points reduce coupling — components can import from a semantic path without knowing the internal `use`-prefix convention, and the domain boundary is documented explicitly.
- **#821**: Without a React hook, components must call `WalletAdapterRegistry.get()` directly and manage their own state — error-prone and not idiomatic. The hook provides a stable, testable integration layer.
- **#822**: The `ThemeProvider` and `ThemeToggle` lived in `src/components/` (outside the shared `ui/` folder), making them invisible to component library consumers who import only from `@/components/ui`.

## How to test

```bash
# TypeScript — should report zero errors in changed files
cd ide && npx tsc --noEmit --skipLibCheck

# Verify scheduleTabSync is now callable:
# import { useCloudSyncStore } from "@/store/useCloudSyncStore";
# const { scheduleTabSync } = useCloudSyncStore(); // no longer a TS error

# Verify domain store imports:
# import { useNetworkStore } from "@/store/networkStore";
# import { useIdentityStore } from "@/store/identityStore";

# Verify wallet DI hook:
# import { useWalletAdapter } from "@/hooks/useWalletAdapter";
# const { connect, publicKey } = useWalletAdapter("freighter");

# Verify UI theme provider:
# import { ThemeProvider, ThemeToggle, useAppTheme } from "@/components/ui/theme-provider";
```