### PR TITLE
feat: integrated context menus for file explorer and editor tabs

### DIFF
--- a/ide/src/components/ide/ContextMenu.tsx
+++ b/ide/src/components/ide/ContextMenu.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { type ReactNode } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  Download,
+  FilePlus,
+  FolderPlus,
+  Pencil,
+  Trash2,
+  X,
+  XCircle,
+  XSquare,
+} from "lucide-react";
+
+// ─── ExplorerContextMenu ──────────────────────────────────────────────────────
+
+export interface ExplorerContextMenuProps {
+  children: ReactNode;
+  path: string[];
+  isFolder: boolean;
+  onNewFile?: (parentPath: string[]) => void;
+  onNewFolder?: (parentPath: string[]) => void;
+  onRename?: (path: string[]) => void;
+  onDelete?: (path: string[]) => void;
+  onDownload?: (path: string[]) => void;
+}
+
+/**
+ * Right-click context menu for file explorer nodes.
+ *
+ * Wraps any element with a Radix-powered context menu that exposes
+ * file/folder operations.  Keyboard navigation (ArrowUp/Down, Enter,
+ * Escape) is provided by Radix UI out of the box.
+ */
+export function ExplorerContextMenu({
+  children,
+  path,
+  isFolder,
+  onNewFile,
+  onNewFolder,
+  onRename,
+  onDelete,
+  onDownload,
+}: ExplorerContextMenuProps) {
+  const hasCreationActions = isFolder && (onNewFile || onNewFolder);
+  const hasEditActions = onRename || (!isFolder && onDownload);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        {isFolder && onNewFile && (
+          <ContextMenuItem
+            onClick={() => onNewFile(path)}
+            className="gap-2 text-xs"
+          >
+            <FilePlus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            New File
+            <ContextMenuShortcut>N</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+        {isFolder && onNewFolder && (
+          <ContextMenuItem
+            onClick={() => onNewFolder(path)}
+            className="gap-2 text-xs"
+          >
+            <FolderPlus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            New Folder
+          </ContextMenuItem>
+        )}
+
+        {hasCreationActions && hasEditActions && <ContextMenuSeparator />}
+
+        {onRename && (
+          <ContextMenuItem
+            onClick={() => onRename(path)}
+            className="gap-2 text-xs"
+          >
+            <Pencil className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Rename
+            <ContextMenuShortcut>F2</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+        {!isFolder && onDownload && (
+          <ContextMenuItem
+            onClick={() => onDownload(path)}
+            className="gap-2 text-xs"
+          >
+            <Download className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Download
+          </ContextMenuItem>
+        )}
+
+        {(hasCreationActions || hasEditActions) && onDelete && (
+          <ContextMenuSeparator />
+        )}
+
+        {onDelete && (
+          <ContextMenuItem
+            onClick={() => onDelete(path)}
+            className="gap-2 text-xs text-destructive focus:text-destructive"
+          >
+            <Trash2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Delete
+            <ContextMenuShortcut>Del</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+// ─── TabContextMenu ───────────────────────────────────────────────────────────
+
+export interface TabContextMenuProps {
+  children: ReactNode;
+  path: string[];
+  onClose?: (path: string[]) => void;
+  onCloseOthers?: (path: string[]) => void;
+  onCloseAll?: () => void;
+  onRename?: (path: string[]) => void;
+  onDownload?: (path: string[]) => void;
+}
+
+/**
+ * Right-click context menu for editor tabs.
+ *
+ * Exposes close variants (this tab, others, all) plus rename and
+ * download actions.  Keyboard navigation is handled by Radix UI.
+ */
+export function TabContextMenu({
+  children,
+  path,
+  onClose,
+  onCloseOthers,
+  onCloseAll,
+  onRename,
+  onDownload,
+}: TabContextMenuProps) {
+  const hasCloseActions = onClose || onCloseOthers || onCloseAll;
+  const hasFileActions = onRename || onDownload;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        {onClose && (
+          <ContextMenuItem
+            onClick={() => onClose(path)}
+            className="gap-2 text-xs"
+          >
+            <X className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Close
+            <ContextMenuShortcut>Ctrl+W</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+        {onCloseOthers && (
+          <ContextMenuItem
+            onClick={() => onCloseOthers(path)}
+            className="gap-2 text-xs"
+          >
+            <XCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Close Others
+          </ContextMenuItem>
+        )}
+        {onCloseAll && (
+          <ContextMenuItem
+            onClick={onCloseAll}
+            className="gap-2 text-xs"
+          >
+            <XSquare className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Close All
+          </ContextMenuItem>
+        )}
+
+        {hasCloseActions && hasFileActions && <ContextMenuSeparator />}
+
+        {onRename && (
+          <ContextMenuItem
+            onClick={() => onRename(path)}
+            className="gap-2 text-xs"
+          >
+            <Pencil className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Rename
+            <ContextMenuShortcut>F2</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+        {onDownload && (
+          <ContextMenuItem
+            onClick={() => onDownload(path)}
+            className="gap-2 text-xs"
+          >
+            <Download className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Download
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}


### PR DESCRIPTION


Implements ExplorerContextMenu and TabContextMenu components in
ide/src/components/ide/ContextMenu.tsx, built on the existing
@radix-ui/react-context-menu primitives already present in the codebase.

ExplorerContextMenu wraps any file tree node with a right-click menu
that exposes New File, New Folder (for folders), Rename, Download (for
files), and Delete. Separators group creation, edit, and destructive
actions visually. Each action is driven by optional callback props so
the component stays decoupled from store internals and callers retain
full control over the handler implementation.

TabContextMenu wraps any editor tab with Close, Close Others, Close All,
Rename, and Download actions. Keyboard shortcuts are shown inline via
ContextMenuShortcut (F2, Del, Ctrl+W) to reinforce discoverability.

Keyboard navigation within the menu (ArrowUp, ArrowDown, Enter, Escape,
Home, End) is provided natively by Radix UI and requires no additional
implementation.

The file is placed in src/components/ide/ rather than src/components/ui/
because it is an IDE-specific integration component, not a generic
design-system primitive. The existing src/components/ui/context-menu.tsx
(the Radix primitive wrapper) is untouched and remains the dependency
of this new component.

closes #817
closes #825
closes #829
closes #830
