### PR TITLE
feat: user-profile-management

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,71 +1,581 @@
 "use client";
 
 import React, { useState } from "react";
-import Navbar from "@/components/Navbar";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import {
+  Check,
+  Copy,
+  Github,
+  Link2,
+  Loader2,
+  Plus,
+  Shield,
+  Star,
+  Trash2,
+  Unlink,
+  Wallet,
+} from "lucide-react";
+
 import Footer from "@/components/Footer";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useIdentity } from "@/hooks/use-identity";
+import {
+  ProfileFields,
+  githubUsernameSchema,
+  initialsFromName,
+  isStellarSecretKey,
+  profileSchema,
+  stellarAccountSchema,
+  truncateAddress,
+} from "@/lib/identity";
 
 export default function ProfilePage() {
-  const [bio, setBio] = useState("");
-  const [avatar, setAvatar] = useState("");
+  const {
+    identity,
+    isLoaded,
+    updateProfile,
+    linkGithub,
+    unlinkGithub,
+    addStellarAccount,
+    removeStellarAccount,
+    setPrimaryStellarAccount,
+  } = useIdentity();
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <Navbar />
-      <main className="flex-1 max-w-4xl w-full mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        <h1 className="text-3xl font-bold text-foreground mb-8">User Profile & Identity</h1>
-        
-        <div className="bg-card shadow-sm border rounded-xl p-6 mb-8">
-          <h2 className="text-xl font-semibold mb-4 text-card-foreground">Edit Profile</h2>
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium mb-1 text-muted-foreground">Avatar URL</label>
-              <input 
-                type="text" 
-                value={avatar} 
-                onChange={(e) => setAvatar(e.target.value)}
-                className="w-full px-3 py-2 border rounded-md bg-background text-foreground"
-                placeholder="https://..."
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1 text-muted-foreground">Bio</label>
-              <textarea 
-                value={bio} 
-                onChange={(e) => setBio(e.target.value)}
-                className="w-full px-3 py-2 border rounded-md bg-background text-foreground"
-                rows={4}
-                placeholder="Tell us about yourself..."
-              />
-            </div>
-            <button className="bg-primary text-primary-foreground px-4 py-2 rounded-md hover:opacity-90 transition-opacity">
-              Save Profile
-            </button>
-          </div>
-        </div>
+      <main
+        id="main-content"
+        className="flex-1 w-full max-w-3xl mx-auto py-10 px-4 sm:px-6 lg:px-8"
+      >
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            Profile &amp; Identity
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            Personalize your developer profile and manage the accounts linked to it.
+          </p>
+        </header>
 
-        <div className="bg-card shadow-sm border rounded-xl p-6">
-          <h2 className="text-xl font-semibold mb-4 text-card-foreground">Linked Accounts</h2>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between p-4 border rounded-lg bg-background">
-              <div className="flex items-center space-x-3">
-                <span className="font-medium text-foreground">GitHub</span>
-              </div>
-              <button className="text-sm bg-secondary text-secondary-foreground px-4 py-2 rounded-md hover:bg-secondary/80 transition-colors">
-                Link Account
-              </button>
-            </div>
-            <div className="flex items-center justify-between p-4 border rounded-lg bg-background">
-              <div className="flex items-center space-x-3">
-                <span className="font-medium text-foreground">Stellar Wallet</span>
-              </div>
-              <button className="text-sm bg-secondary text-secondary-foreground px-4 py-2 rounded-md hover:bg-secondary/80 transition-colors">
-                Connect Wallet
-              </button>
-            </div>
+        {!isLoaded ? (
+          <div className="flex items-center justify-center py-24 text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden />
+            Loading your profile…
           </div>
-        </div>
+        ) : (
+          <Tabs defaultValue="profile" className="w-full">
+            <TabsList className="mb-6">
+              <TabsTrigger value="profile">Edit Profile</TabsTrigger>
+              <TabsTrigger value="accounts">
+                Linked Accounts
+                <Badge variant="secondary" className="ml-2">
+                  {(identity.github ? 1 : 0) + identity.stellarAccounts.length}
+                </Badge>
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="profile">
+              <ProfileForm identity={identity} onSave={updateProfile} />
+            </TabsContent>
+
+            <TabsContent value="accounts" className="space-y-6">
+              <GithubCard
+                username={identity.github}
+                onLink={linkGithub}
+                onUnlink={unlinkGithub}
+              />
+              <StellarCard
+                accounts={identity.stellarAccounts}
+                onAdd={addStellarAccount}
+                onRemove={removeStellarAccount}
+                onSetPrimary={setPrimaryStellarAccount}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
       </main>
       <Footer />
     </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Edit profile                                                               */
+/* -------------------------------------------------------------------------- */
+
+function ProfileForm({
+  identity,
+  onSave,
+}: {
+  identity: ProfileFields;
+  onSave: (fields: ProfileFields) => void;
+}) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors, isSubmitting, isDirty },
+  } = useForm<ProfileFields>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      displayName: identity.displayName ?? "",
+      bio: identity.bio ?? "",
+      avatarUrl: identity.avatarUrl ?? "",
+    },
+  });
+
+  const displayName = watch("displayName");
+  const avatarUrl = watch("avatarUrl");
+  const bio = watch("bio") ?? "";
+
+  const onSubmit = (fields: ProfileFields) => {
+    onSave(fields);
+    reset(fields); // clears the dirty state after a successful save
+    toast.success("Profile saved", {
+      description: "Your changes have been stored on this device.",
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Edit profile</CardTitle>
+        <CardDescription>
+          This information personalizes your experience across Stellar Kit.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <div className="flex items-center gap-4">
+            <Avatar className="h-16 w-16">
+              {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+              <AvatarFallback className="text-lg">
+                {initialsFromName(displayName || "")}
+              </AvatarFallback>
+            </Avatar>
+            <div className="text-sm text-muted-foreground">
+              Live preview of your avatar.
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="displayName">Display name</Label>
+            <Input
+              id="displayName"
+              placeholder="Ada Lovelace"
+              aria-invalid={!!errors.displayName}
+              {...register("displayName")}
+            />
+            {errors.displayName ? (
+              <p className="text-sm text-destructive">{errors.displayName.message}</p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="avatarUrl">Avatar URL</Label>
+            <Input
+              id="avatarUrl"
+              type="url"
+              placeholder="https://example.com/avatar.png"
+              aria-invalid={!!errors.avatarUrl}
+              {...register("avatarUrl")}
+            />
+            {errors.avatarUrl ? (
+              <p className="text-sm text-destructive">{errors.avatarUrl.message}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Only http(s) links are allowed.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="bio">Bio</Label>
+              <span className="text-xs text-muted-foreground">{bio.length}/280</span>
+            </div>
+            <Textarea
+              id="bio"
+              rows={4}
+              placeholder="Tell other developers about yourself…"
+              aria-invalid={!!errors.bio}
+              {...register("bio")}
+            />
+            {errors.bio ? (
+              <p className="text-sm text-destructive">{errors.bio.message}</p>
+            ) : null}
+          </div>
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={isSubmitting || !isDirty}>
+              {isSubmitting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+              ) : null}
+              Save profile
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* GitHub linking                                                             */
+/* -------------------------------------------------------------------------- */
+
+function GithubCard({
+  username,
+  onLink,
+  onUnlink,
+}: {
+  username: string | null;
+  onLink: (username: string) => void;
+  onUnlink: () => void;
+}) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLink = () => {
+    const result = githubUsernameSchema.safeParse(value);
+    if (!result.success) {
+      setError(result.error.issues[0].message);
+      return;
+    }
+    setError(null);
+    onLink(result.data);
+    setValue("");
+    toast.success(`Linked @${result.data} on GitHub`);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Github className="h-5 w-5" aria-hidden />
+          GitHub
+        </CardTitle>
+        <CardDescription>
+          Connect your GitHub account to showcase your open-source work.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {username ? (
+          <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/30 p-4">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarImage
+                  src={`https://github.com/${username}.png?size=80`}
+                  alt=""
+                />
+                <AvatarFallback>{username.slice(0, 2).toUpperCase()}</AvatarFallback>
+              </Avatar>
+              <div>
+                <a
+                  href={`https://github.com/${username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-foreground hover:underline"
+                >
+                  @{username}
+                </a>
+                <p className="text-xs text-muted-foreground">Connected</p>
+              </div>
+            </div>
+            <ConfirmButton
+              title="Unlink GitHub?"
+              description={`@${username} will be disconnected from your profile.`}
+              actionLabel="Unlink"
+              onConfirm={() => {
+                onUnlink();
+                toast.success("GitHub account unlinked");
+              }}
+            >
+              <Button variant="outline" size="sm">
+                <Unlink className="mr-2 h-4 w-4" aria-hidden />
+                Unlink
+              </Button>
+            </ConfirmButton>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="github-username" className="sr-only">
+                GitHub username
+              </Label>
+              <div className="flex items-center rounded-md border bg-background focus-within:ring-1 focus-within:ring-ring">
+                <span className="pl-3 text-sm text-muted-foreground">github.com/</span>
+                <Input
+                  id="github-username"
+                  value={value}
+                  onChange={(e) => {
+                    setValue(e.target.value);
+                    if (error) setError(null);
+                  }}
+                  onKeyDown={(e) => e.key === "Enter" && handleLink()}
+                  placeholder="username"
+                  aria-invalid={!!error}
+                  className="border-0 focus-visible:ring-0"
+                />
+              </div>
+              {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            </div>
+            <Button onClick={handleLink}>
+              <Link2 className="mr-2 h-4 w-4" aria-hidden />
+              Link account
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Stellar accounts                                                           */
+/* -------------------------------------------------------------------------- */
+
+function StellarCard({
+  accounts,
+  onAdd,
+  onRemove,
+  onSetPrimary,
+}: {
+  accounts: { address: string; label?: string; primary: boolean }[];
+  onAdd: (address: string, label?: string) => void;
+  onRemove: (address: string) => void;
+  onSetPrimary: (address: string) => void;
+}) {
+  const [address, setAddress] = useState("");
+  const [label, setLabel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    const result = stellarAccountSchema.safeParse({ address, label });
+    if (!result.success) {
+      setError(result.error.issues[0].message);
+      return;
+    }
+    if (accounts.some((a) => a.address === result.data.address)) {
+      setError("That account is already linked");
+      return;
+    }
+    setError(null);
+    onAdd(result.data.address, result.data.label);
+    setAddress("");
+    setLabel("");
+    toast.success("Stellar account linked");
+  };
+
+  const handleCopy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(value);
+      setTimeout(() => setCopied(null), 1500);
+    } catch {
+      toast.error("Couldn't copy to clipboard");
+    }
+  };
+
+  // Surface the secret-key warning as soon as the user pastes one.
+  const secretKeyWarning = isStellarSecretKey(address);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Wallet className="h-5 w-5" aria-hidden />
+          Stellar accounts
+        </CardTitle>
+        <CardDescription>
+          Link the public keys of the Stellar accounts you own.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {accounts.length > 0 ? (
+          <ul className="space-y-2">
+            {accounts.map((account) => (
+              <li
+                key={account.address}
+                className="flex items-center justify-between gap-3 rounded-lg border p-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-sm text-foreground">
+                      {truncateAddress(account.address, 6, 6)}
+                    </span>
+                    {account.primary ? (
+                      <Badge className="gap-1">
+                        <Star className="h-3 w-3" aria-hidden />
+                        Primary
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {account.label ? (
+                    <p className="truncate text-xs text-muted-foreground">
+                      {account.label}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Copy address"
+                    onClick={() => handleCopy(account.address)}
+                  >
+                    {copied === account.address ? (
+                      <Check className="h-4 w-4 text-green-500" aria-hidden />
+                    ) : (
+                      <Copy className="h-4 w-4" aria-hidden />
+                    )}
+                  </Button>
+                  {!account.primary ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        onSetPrimary(account.address);
+                        toast.success("Primary account updated");
+                      }}
+                    >
+                      Make primary
+                    </Button>
+                  ) : null}
+                  <ConfirmButton
+                    title="Remove account?"
+                    description={`${truncateAddress(
+                      account.address,
+                      6,
+                      6,
+                    )} will be unlinked from your profile.`}
+                    actionLabel="Remove"
+                    onConfirm={() => {
+                      onRemove(account.address);
+                      toast.success("Stellar account removed");
+                    }}
+                  >
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Remove account"
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" aria-hidden />
+                    </Button>
+                  </ConfirmButton>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+            No Stellar accounts linked yet.
+          </p>
+        )}
+
+        <div className="space-y-2 border-t pt-4">
+          <Label htmlFor="stellar-address">Add an account</Label>
+          <Input
+            id="stellar-address"
+            value={address}
+            onChange={(e) => {
+              setAddress(e.target.value);
+              if (error) setError(null);
+            }}
+            placeholder="G… public key"
+            aria-invalid={!!error}
+            className="font-mono"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Input
+            aria-label="Account label (optional)"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Label (optional), e.g. Testnet wallet"
+            maxLength={30}
+          />
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {secretKeyWarning ? (
+            <p className="flex items-center gap-1.5 text-sm text-destructive">
+              <Shield className="h-4 w-4" aria-hidden />
+              Never enter a secret key. Only public keys (starting with G) are stored.
+            </p>
+          ) : (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Shield className="h-3.5 w-3.5" aria-hidden />
+              Only public keys are stored — never share your secret key.
+            </p>
+          )}
+          <div className="flex justify-end">
+            <Button onClick={handleAdd} disabled={!address.trim()}>
+              <Plus className="mr-2 h-4 w-4" aria-hidden />
+              Link account
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Shared confirm dialog                                                      */
+/* -------------------------------------------------------------------------- */
+
+function ConfirmButton({
+  title,
+  description,
+  actionLabel,
+  onConfirm,
+  children,
+}: {
+  title: string;
+  description: string;
+  actionLabel: string;
+  onConfirm: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>{actionLabel}</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/frontend/src/hooks/use-identity.ts
+++ b/frontend/src/hooks/use-identity.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+import {
+  EMPTY_IDENTITY,
+  Identity,
+  LinkedStellarAccount,
+  ProfileFields,
+  STORAGE_KEY,
+  loadIdentity,
+  saveIdentity,
+} from "@/lib/identity";
+
+/**
+ * Module-level identity store backed by localStorage.
+ *
+ * Exposed through `useSyncExternalStore` so it is SSR-safe (server renders the
+ * empty identity, the client re-renders with persisted data after hydration),
+ * stays consistent across every component that reads it, and syncs across tabs
+ * via the `storage` event — all without `setState`-in-effect.
+ */
+let store: Identity | null = null;
+const listeners = new Set<() => void>();
+let storageBound = false;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function getSnapshot(): Identity {
+  if (store === null) store = loadIdentity();
+  return store;
+}
+
+function getServerSnapshot(): Identity {
+  return EMPTY_IDENTITY;
+}
+
+function handleStorageEvent(event: StorageEvent) {
+  if (event.key === STORAGE_KEY) {
+    store = loadIdentity();
+    emit();
+  }
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (!storageBound && typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorageEvent);
+    storageBound = true;
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Replace the store with a new identity, persist it, and notify subscribers. */
+function setStore(updater: (prev: Identity) => Identity) {
+  const next = updater(getSnapshot());
+  if (next === store) return;
+  store = next;
+  saveIdentity(next);
+  emit();
+}
+
+// `isLoaded` flips from false (server/hydration) to true on the client, so the
+// UI can avoid initialising forms from the empty server snapshot.
+const subscribeNoop = () => () => {};
+const getTrue = () => true;
+const getFalse = () => false;
+
+export function useIdentity() {
+  const identity = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const isLoaded = useSyncExternalStore(subscribeNoop, getTrue, getFalse);
+
+  const updateProfile = useCallback(
+    (fields: ProfileFields) => setStore((prev) => ({ ...prev, ...fields })),
+    [],
+  );
+
+  const linkGithub = useCallback(
+    (username: string) => setStore((prev) => ({ ...prev, github: username })),
+    [],
+  );
+
+  const unlinkGithub = useCallback(
+    () => setStore((prev) => ({ ...prev, github: null })),
+    [],
+  );
+
+  const addStellarAccount = useCallback(
+    (address: string, label?: string) =>
+      setStore((prev) => {
+        if (prev.stellarAccounts.some((a) => a.address === address)) return prev;
+        const account: LinkedStellarAccount = {
+          address,
+          label: label || undefined,
+          // The first account added becomes the primary one.
+          primary: prev.stellarAccounts.length === 0,
+        };
+        return { ...prev, stellarAccounts: [...prev.stellarAccounts, account] };
+      }),
+    [],
+  );
+
+  const removeStellarAccount = useCallback(
+    (address: string) =>
+      setStore((prev) => {
+        const remaining = prev.stellarAccounts.filter((a) => a.address !== address);
+        // If we removed the primary, promote the first remaining account.
+        if (remaining.length > 0 && !remaining.some((a) => a.primary)) {
+          remaining[0] = { ...remaining[0], primary: true };
+        }
+        return { ...prev, stellarAccounts: remaining };
+      }),
+    [],
+  );
+
+  const setPrimaryStellarAccount = useCallback(
+    (address: string) =>
+      setStore((prev) => ({
+        ...prev,
+        stellarAccounts: prev.stellarAccounts.map((a) => ({
+          ...a,
+          primary: a.address === address,
+        })),
+      })),
+    [],
+  );
+
+  return {
+    identity,
+    isLoaded,
+    updateProfile,
+    linkGithub,
+    unlinkGithub,
+    addStellarAccount,
+    removeStellarAccount,
+    setPrimaryStellarAccount,
+  };
+}

--- a/frontend/src/lib/identity.ts
+++ b/frontend/src/lib/identity.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+/**
+ * Client-side identity & profile model.
+ *
+ * The marketing/app frontend has no auth backend yet, so identity is persisted
+ * locally (localStorage) behind a small, validated API. Everything here is
+ * SSR-safe and treats all input as untrusted: values are schema-validated before
+ * they are stored, and only *public* Stellar keys are ever accepted.
+ */
+
+export const STORAGE_KEY = "stellar-kit:identity";
+
+/** Stellar StrKey-encoded public keys: 'G' + 55 base32 chars (A-Z, 2-7). */
+const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+/** A Stellar secret key starts with 'S' — we must never store one. */
+const STELLAR_SECRET_KEY_REGEX = /^S[A-Z2-7]{55}$/;
+/** GitHub usernames: 1-39 chars, alphanumeric or single hyphens, no edges. */
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+
+export function isValidStellarPublicKey(value: string): boolean {
+  return STELLAR_PUBLIC_KEY_REGEX.test(value.trim());
+}
+
+export function isStellarSecretKey(value: string): boolean {
+  return STELLAR_SECRET_KEY_REGEX.test(value.trim());
+}
+
+/** Shorten a Stellar address for display, e.g. GABC…WXYZ. */
+export function truncateAddress(address: string, lead = 4, tail = 4): string {
+  if (address.length <= lead + tail) return address;
+  return `${address.slice(0, lead)}…${address.slice(-tail)}`;
+}
+
+export const profileSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .max(50, "Display name must be 50 characters or fewer"),
+  bio: z.string().trim().max(280, "Bio must be 280 characters or fewer"),
+  // Empty is allowed (no avatar); otherwise must be a valid http(s) URL.
+  // Restricting to http(s) avoids javascript:/data: injection vectors.
+  avatarUrl: z
+    .string()
+    .trim()
+    .refine(
+      (url) => url === "" || /^https?:\/\/.+/i.test(url),
+      "Avatar URL must start with http:// or https://",
+    )
+    .refine(
+      (url) => url === "" || z.string().url().safeParse(url).success,
+      "Enter a valid URL",
+    ),
+});
+
+export const githubUsernameSchema = z
+  .string()
+  .trim()
+  .min(1, "Enter a GitHub username")
+  .regex(GITHUB_USERNAME_REGEX, "That doesn't look like a valid GitHub username");
+
+export const stellarAccountSchema = z.object({
+  address: z
+    .string()
+    .trim()
+    .refine(
+      (value) => !isStellarSecretKey(value),
+      "That's a secret key — never share it. Enter your public key (starts with G).",
+    )
+    .refine(
+      isValidStellarPublicKey,
+      "Enter a valid Stellar public key (starts with G, 56 characters)",
+    ),
+  label: z.string().trim().max(30, "Label must be 30 characters or fewer").optional(),
+});
+
+export type ProfileFields = z.infer<typeof profileSchema>;
+
+export interface LinkedStellarAccount {
+  address: string;
+  label?: string;
+  primary: boolean;
+}
+
+export interface Identity {
+  displayName: string;
+  bio: string;
+  avatarUrl: string;
+  github: string | null;
+  stellarAccounts: LinkedStellarAccount[];
+}
+
+export const EMPTY_IDENTITY: Identity = {
+  displayName: "",
+  bio: "",
+  avatarUrl: "",
+  github: null,
+  stellarAccounts: [],
+};
+
+/** Derive avatar fallback initials from the display name (or a default). */
+export function initialsFromName(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "SK";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/** Read identity from localStorage, tolerating absent/corrupt data. */
+export function loadIdentity(): Identity {
+  if (typeof window === "undefined") return EMPTY_IDENTITY;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_IDENTITY;
+    const parsed = JSON.parse(raw) as Partial<Identity>;
+    return {
+      ...EMPTY_IDENTITY,
+      ...parsed,
+      stellarAccounts: Array.isArray(parsed.stellarAccounts)
+        ? parsed.stellarAccounts.filter((a) => isValidStellarPublicKey(a.address))
+        : [],
+    };
+  } catch {
+    return EMPTY_IDENTITY;
+  }
+}
+
+/** Persist identity to localStorage. */
+export function saveIdentity(identity: Identity): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(identity));
+  } catch {
+    /* storage may be full or unavailable — ignore */
+  }
+}


### PR DESCRIPTION

<img width="1280" height="1264" alt="profile-desktop-accounts" src="https://github.com/user-attachments/assets/f6ededc3-da8a-4d65-9da9-ed900803655a" />
<img width="1280" height="1264" alt="profile-desktop-edit" src="https://github.com/user-attachments/assets/d5501438-ef18-45b5-a13f-250a9a36a588" />
<img width="390" height="1464" alt="profile-mobile-accounts" src="https://github.com/user-attachments/assets/aeae766c-f31f-4fb2-a6da-0e0340e2aad3" />
Closes #863

## What & why

Implements **issue #863 — User Profile and Identity Management UI**. Replaces the non-functional profile stub with a complete, persisted profile & identity management experience. Personalizes the developer experience while handling identity data safely.

All changes are confined to the `frontend/` directory.

## Acceptance criteria

- ✅ **Edit profile** — display name, avatar URL (with live preview) and bio, validated with `react-hook-form` + `zod`, persisted locally and surfaced via toasts.
- ✅ **Linked accounts management (GitHub, Stellar)** — link/unlink GitHub; add/remove multiple Stellar public keys, set a primary, copy address; all with confirm dialogs.

## Deliverable + supporting files

- `src/app/profile/page.tsx` — tabbed **Edit Profile / Linked Accounts** UI built from the existing shadcn component kit (Card, Tabs, Avatar, Badge, AlertDialog, Input, Textarea…).
- `src/lib/identity.ts` — zod-validated identity model + SSR-safe localStorage persistence.
- `src/hooks/use-identity.ts` — reactive identity store via `useSyncExternalStore`, persisted to localStorage and synced across tabs.

## Secure / robust data handling

- Stellar **secret keys are rejected** (only `G…` public keys are accepted/stored), with an inline warning the moment an `S…` key is pasted.
- Avatar URLs are restricted to `http(s)` (blocks `javascript:`/`data:` vectors).
- All inputs are schema-validated; corrupt/persisted data is filtered on load.
- Removed a latent double-`<Navbar>` bug by following the app-page convention (the global layout already renders the navbar).

## Verified output

```
$ npx tsc --noEmit      → exit 0 (no type errors)
$ npx eslint <files>    → 0 errors (1 benign react-hook-form warning)
$ npm run build         → ✓ Compiled successfully; /profile prerendered (○ Static)
```

## Screenshots

Functional screenshots (seeded state) captured via system Chrome at desktop & mobile widths — **Edit Profile** (avatar preview + 280-char bio counter) and **Linked Accounts** (GitHub connected, two Stellar accounts with primary badge, secret-key warning). _Drag the images into this description:_

- `profile-desktop-edit.png`
- `profile-desktop-accounts.png`
- `profile-mobile-accounts.png`
