### PR TITLE
feat: interactive-roadmap-ui

### DIFF
--- a/frontend/src/app/roadmap/page.tsx
+++ b/frontend/src/app/roadmap/page.tsx
@@ -1,72 +1,285 @@
 "use client";
 
-import React, { useState } from "react";
-import Navbar from "@/components/Navbar";
+import React, { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import { ChevronUp, Loader2, Plus, Sparkles } from "lucide-react";
+
 import Footer from "@/components/Footer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { useRoadmap } from "@/hooks/use-roadmap";
+import {
+  FeatureRequestInput,
+  RoadmapItem,
+  STATUS_META,
+  STATUS_ORDER,
+  featureRequestSchema,
+} from "@/lib/roadmap";
 
 export default function RoadmapPage() {
-  const [features, setFeatures] = useState([
-    { id: 1, title: "Dark Mode Support", status: "Done", votes: 120 },
-    { id: 2, title: "Soroban CLI Integration", status: "In Progress", votes: 85 },
-    { id: 3, title: "Advanced Testnet Faucet", status: "Planned", votes: 45 },
-    { id: 4, title: "Template Generator", status: "Planned", votes: 30 },
-  ]);
+  const { isLoaded, items, votesFor, hasVoted, toggleVote, submitRequest } =
+    useRoadmap();
 
-  const handleVote = (id: number) => {
-    setFeatures(features.map(f => f.id === id ? { ...f, votes: f.votes + 1 } : f));
-  };
+  // Group + sort items by status; most-voted first within each column.
+  const columns = useMemo(() => {
+    return STATUS_ORDER.map((status) => ({
+      status,
+      items: items
+        .filter((item) => item.status === status)
+        .sort((a, b) => votesFor(b) - votesFor(a)),
+    }));
+  }, [items, votesFor]);
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <Navbar />
-      <main className="flex-1 max-w-6xl w-full mx-auto py-12 px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-foreground mb-4">Interactive Roadmap</h1>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            Community-driven product development. View our progress, vote on feature requests, or submit your own ideas to help shape the future of Stellar Suite.
+      <main
+        id="main-content"
+        className="flex-1 w-full max-w-6xl mx-auto py-12 px-4 sm:px-6 lg:px-8"
+      >
+        <header className="mb-10 text-center">
+          <h1 className="text-4xl font-bold tracking-tight text-foreground">
+            Roadmap &amp; Feature Requests
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-lg text-muted-foreground">
+            See what we&apos;re building, upvote the ideas you care about, and
+            submit your own to help shape Stellar Kit.
           </p>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {["Planned", "In Progress", "Done"].map(status => (
-            <div key={status} className="bg-card shadow-sm border rounded-xl p-6 flex flex-col">
-              <h2 className="text-xl font-semibold mb-4 border-b pb-3 text-card-foreground">
-                {status} <span className="text-sm font-normal text-muted-foreground ml-2">({features.filter(f => f.status === status).length})</span>
-              </h2>
-              <div className="space-y-4 flex-1">
-                {features.filter(f => f.status === status).map(feature => (
-                  <div key={feature.id} className="p-4 border rounded-lg bg-background flex flex-col justify-between hover:border-primary/50 transition-colors">
-                    <h3 className="font-medium mb-3 text-foreground">{feature.title}</h3>
-                    <div className="flex items-center justify-between mt-auto pt-2">
-                      <span className="text-sm text-muted-foreground font-medium">{feature.votes} votes</span>
-                      <button 
-                        onClick={() => handleVote(feature.id)}
-                        className="text-sm bg-primary/10 text-primary px-3 py-1.5 rounded-md hover:bg-primary/20 transition-colors flex items-center font-medium"
-                      >
-                        <span className="mr-1">▲</span> Upvote
-                      </button>
-                    </div>
-                  </div>
-                ))}
-                {features.filter(f => f.status === status).length === 0 && (
-                  <div className="text-center py-8 text-muted-foreground text-sm">
-                    No items in this column.
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
+          <div className="mt-6 flex justify-center">
+            <SubmitRequestDialog onSubmit={submitRequest} />
+          </div>
+        </header>
 
-        <div className="mt-12 bg-primary/5 rounded-xl p-8 text-center border border-primary/10">
-          <h3 className="text-2xl font-semibold mb-3">Have a Feature Request?</h3>
-          <p className="text-muted-foreground mb-6">We are always looking for ways to improve our tools for the Stellar community.</p>
-          <button className="bg-primary text-primary-foreground px-6 py-3 rounded-md font-medium hover:opacity-90 transition-opacity">
-            Submit Request
-          </button>
-        </div>
+        {!isLoaded ? (
+          <div className="flex items-center justify-center py-24 text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden />
+            Loading roadmap…
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            {columns.map((column) => {
+              const meta = STATUS_META[column.status];
+              return (
+                <section
+                  key={column.status}
+                  aria-label={meta.label}
+                  className="flex flex-col rounded-xl border bg-card/40 p-4"
+                >
+                  <div className="mb-4 flex items-center gap-2 border-b pb-3">
+                    <span
+                      className={cn("h-2.5 w-2.5 rounded-full", meta.dotClass)}
+                      aria-hidden
+                    />
+                    <h2 className="font-semibold text-card-foreground">
+                      {meta.label}
+                    </h2>
+                    <span className="ml-auto text-sm text-muted-foreground">
+                      {column.items.length}
+                    </span>
+                  </div>
+
+                  <div className="flex-1 space-y-3">
+                    {column.items.map((item) => (
+                      <RoadmapCard
+                        key={item.id}
+                        item={item}
+                        votes={votesFor(item)}
+                        voted={hasVoted(item.id)}
+                        onVote={() => toggleVote(item.id)}
+                      />
+                    ))}
+                    {column.items.length === 0 ? (
+                      <p className="py-8 text-center text-sm text-muted-foreground">
+                        Nothing here yet.
+                      </p>
+                    ) : null}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        )}
       </main>
       <Footer />
     </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Roadmap card                                                               */
+/* -------------------------------------------------------------------------- */
+
+function RoadmapCard({
+  item,
+  votes,
+  voted,
+  onVote,
+}: {
+  item: RoadmapItem;
+  votes: number;
+  voted: boolean;
+  onVote: () => void;
+}) {
+  const meta = STATUS_META[item.status];
+  return (
+    <Card className="transition-colors hover:border-primary/40">
+      <CardHeader className="space-y-2 pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="font-medium leading-snug text-foreground">
+            {item.title}
+          </h3>
+          {item.community ? (
+            <Badge variant="outline" className="shrink-0 gap-1">
+              <Sparkles className="h-3 w-3" aria-hidden />
+              Community
+            </Badge>
+          ) : null}
+        </div>
+        {item.description ? (
+          <p className="text-sm text-muted-foreground">{item.description}</p>
+        ) : null}
+      </CardHeader>
+      <CardContent className="pb-3">
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+            meta.badgeClass,
+          )}
+        >
+          {meta.label}
+        </span>
+      </CardContent>
+      <CardFooter className="justify-between border-t pt-3">
+        <span className="text-sm text-muted-foreground">
+          {votes} {votes === 1 ? "vote" : "votes"}
+        </span>
+        <Button
+          variant={voted ? "default" : "outline"}
+          size="sm"
+          onClick={onVote}
+          aria-pressed={voted}
+          aria-label={voted ? `Remove your vote from ${item.title}` : `Upvote ${item.title}`}
+        >
+          <ChevronUp className="mr-1 h-4 w-4" aria-hidden />
+          {voted ? "Voted" : "Upvote"}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Submit feature request                                                     */
+/* -------------------------------------------------------------------------- */
+
+function SubmitRequestDialog({
+  onSubmit,
+}: {
+  onSubmit: (input: FeatureRequestInput) => RoadmapItem;
+}) {
+  const [open, setOpen] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FeatureRequestInput>({
+    resolver: zodResolver(featureRequestSchema),
+    defaultValues: { title: "", description: "" },
+  });
+
+  const description = watch("description") ?? "";
+
+  const submit = (values: FeatureRequestInput) => {
+    onSubmit(values);
+    toast.success("Feature request submitted", {
+      description: "It's now in the Planned column with your upvote.",
+    });
+    reset();
+    setOpen(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" aria-hidden />
+          Submit a feature request
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Submit a feature request</DialogTitle>
+          <DialogDescription>
+            Share an idea with the community. It starts in Planned and others can
+            upvote it.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(submit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="request-title">Title</Label>
+            <Input
+              id="request-title"
+              placeholder="e.g. Multi-sig transaction builder"
+              aria-invalid={!!errors.title}
+              {...register("title")}
+            />
+            {errors.title ? (
+              <p className="text-sm text-destructive">{errors.title.message}</p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="request-description">Description (optional)</Label>
+              <span className="text-xs text-muted-foreground">
+                {description.length}/280
+              </span>
+            </div>
+            <Textarea
+              id="request-description"
+              rows={4}
+              placeholder="What problem would this solve?"
+              aria-invalid={!!errors.description}
+              {...register("description")}
+            />
+            {errors.description ? (
+              <p className="text-sm text-destructive">
+                {errors.description.message}
+              </p>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+              ) : null}
+              Submit request
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/hooks/use-roadmap.ts
+++ b/frontend/src/hooks/use-roadmap.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import {
+  EMPTY_STATE,
+  FeatureRequestInput,
+  RoadmapItem,
+  RoadmapState,
+  SEED_ITEMS,
+  STORAGE_KEY,
+  loadState,
+  saveState,
+} from "@/lib/roadmap";
+
+/**
+ * Module-level roadmap store backed by localStorage, exposed via
+ * `useSyncExternalStore` so it is SSR-safe and consistent across components and
+ * browser tabs (mirrors the identity store pattern).
+ */
+let store: RoadmapState | null = null;
+const listeners = new Set<() => void>();
+let storageBound = false;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function getSnapshot(): RoadmapState {
+  if (store === null) store = loadState();
+  return store;
+}
+
+function getServerSnapshot(): RoadmapState {
+  return EMPTY_STATE;
+}
+
+function handleStorageEvent(event: StorageEvent) {
+  if (event.key === STORAGE_KEY) {
+    store = loadState();
+    emit();
+  }
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  if (!storageBound && typeof window !== "undefined") {
+    window.addEventListener("storage", handleStorageEvent);
+    storageBound = true;
+  }
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function setStore(updater: (prev: RoadmapState) => RoadmapState) {
+  const next = updater(getSnapshot());
+  if (next === store) return;
+  store = next;
+  saveState(next);
+  emit();
+}
+
+const subscribeNoop = () => () => {};
+const getTrue = () => true;
+const getFalse = () => false;
+
+export function useRoadmap() {
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const isLoaded = useSyncExternalStore(subscribeNoop, getTrue, getFalse);
+
+  // Seed items first, then the visitor's own submissions.
+  const items = useMemo<RoadmapItem[]>(
+    () => [...SEED_ITEMS, ...state.submitted],
+    [state.submitted],
+  );
+
+  const votedIds = useMemo(() => new Set(state.votedIds), [state.votedIds]);
+
+  /** Total votes shown = baseline + the visitor's own vote (if cast). */
+  const votesFor = useCallback(
+    (item: RoadmapItem) => item.baseVotes + (votedIds.has(item.id) ? 1 : 0),
+    [votedIds],
+  );
+
+  const hasVoted = useCallback((id: string) => votedIds.has(id), [votedIds]);
+
+  const toggleVote = useCallback(
+    (id: string) =>
+      setStore((prev) => {
+        const voted = prev.votedIds.includes(id);
+        return {
+          ...prev,
+          votedIds: voted
+            ? prev.votedIds.filter((v) => v !== id)
+            : [...prev.votedIds, id],
+        };
+      }),
+    [],
+  );
+
+  const submitRequest = useCallback((input: FeatureRequestInput): RoadmapItem => {
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? `req-${crypto.randomUUID()}`
+        : `req-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const item: RoadmapItem = {
+      id,
+      title: input.title,
+      description: input.description?.trim() || undefined,
+      status: "planned",
+      baseVotes: 0,
+      community: true,
+    };
+    setStore((prev) => ({
+      submitted: [...prev.submitted, item],
+      // The author automatically upvotes their own request.
+      votedIds: [...prev.votedIds, id],
+    }));
+    return item;
+  }, []);
+
+  return {
+    isLoaded,
+    items,
+    votesFor,
+    hasVoted,
+    toggleVote,
+    submitRequest,
+  };
+}

--- a/frontend/src/lib/roadmap.ts
+++ b/frontend/src/lib/roadmap.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+/**
+ * Roadmap & feature-request model.
+ *
+ * The frontend has no backend yet, so roadmap state is persisted locally:
+ *  - a fixed set of seeded roadmap items (the "official" roadmap), and
+ *  - user-submitted feature requests + the set of items the visitor upvoted.
+ *
+ * Vote counts are never mutated on the seed items; the visitor's own vote is
+ * layered on top via `votedIds`, which keeps voting idempotent (one vote per
+ * visitor, toggleable) without a server.
+ */
+
+export const STORAGE_KEY = "stellar-kit:roadmap";
+
+export type RoadmapStatus = "planned" | "in-progress" | "done";
+
+export interface RoadmapItem {
+  id: string;
+  title: string;
+  description?: string;
+  status: RoadmapStatus;
+  /** Baseline community votes (excludes the current visitor's vote). */
+  baseVotes: number;
+  /** True for items submitted by the visitor on this device. */
+  community?: boolean;
+}
+
+/** Ordered status metadata used for columns, badges and indicators. */
+export const STATUS_ORDER: RoadmapStatus[] = ["planned", "in-progress", "done"];
+
+export const STATUS_META: Record<
+  RoadmapStatus,
+  { label: string; badgeClass: string; dotClass: string }
+> = {
+  planned: {
+    label: "Planned",
+    badgeClass: "bg-muted text-muted-foreground",
+    dotClass: "bg-muted-foreground",
+  },
+  "in-progress": {
+    label: "In Progress",
+    badgeClass: "bg-blue-500/15 text-blue-500",
+    dotClass: "bg-blue-500",
+  },
+  done: {
+    label: "Done",
+    badgeClass: "bg-green-500/15 text-green-500",
+    dotClass: "bg-green-500",
+  },
+};
+
+/** The seeded, "official" roadmap. */
+export const SEED_ITEMS: RoadmapItem[] = [
+  {
+    id: "seed-dark-mode",
+    title: "Dark mode support",
+    description: "A first-class dark theme across the entire IDE and website.",
+    status: "done",
+    baseVotes: 120,
+  },
+  {
+    id: "seed-soroban-cli",
+    title: "Soroban CLI integration",
+    description: "Run soroban-cli commands directly from the in-browser terminal.",
+    status: "in-progress",
+    baseVotes: 85,
+  },
+  {
+    id: "seed-faucet",
+    title: "Advanced testnet faucet",
+    description: "Fund test accounts with custom assets and amounts in one click.",
+    status: "in-progress",
+    baseVotes: 64,
+  },
+  {
+    id: "seed-template-generator",
+    title: "Contract template generator",
+    description: "Scaffold common Soroban contracts from vetted templates.",
+    status: "planned",
+    baseVotes: 45,
+  },
+  {
+    id: "seed-collab",
+    title: "Real-time collaboration",
+    description: "Pair-program on contracts with shared cursors and presence.",
+    status: "planned",
+    baseVotes: 30,
+  },
+];
+
+export const featureRequestSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(3, "Give your idea a short title (at least 3 characters)")
+    .max(80, "Keep the title under 80 characters"),
+  description: z
+    .string()
+    .trim()
+    .max(280, "Keep the description under 280 characters")
+    .optional(),
+});
+
+export type FeatureRequestInput = z.infer<typeof featureRequestSchema>;
+
+export interface RoadmapState {
+  /** Feature requests submitted by the visitor on this device. */
+  submitted: RoadmapItem[];
+  /** Ids of items the visitor has upvoted. */
+  votedIds: string[];
+}
+
+export const EMPTY_STATE: RoadmapState = { submitted: [], votedIds: [] };
+
+const isRoadmapStatus = (value: unknown): value is RoadmapStatus =>
+  value === "planned" || value === "in-progress" || value === "done";
+
+/** Read roadmap state from localStorage, tolerating absent/corrupt data. */
+export function loadState(): RoadmapState {
+  if (typeof window === "undefined") return EMPTY_STATE;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_STATE;
+    const parsed = JSON.parse(raw) as Partial<RoadmapState>;
+    const submitted = Array.isArray(parsed.submitted)
+      ? parsed.submitted.filter(
+          (item): item is RoadmapItem =>
+            !!item &&
+            typeof item.id === "string" &&
+            typeof item.title === "string" &&
+            isRoadmapStatus(item.status),
+        )
+      : [];
+    const votedIds = Array.isArray(parsed.votedIds)
+      ? parsed.votedIds.filter((id): id is string => typeof id === "string")
+      : [];
+    return { submitted, votedIds };
+  } catch {
+    return EMPTY_STATE;
+  }
+}
+
+export function saveState(state: RoadmapState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    /* storage may be full or unavailable — ignore */
+  }
+}


### PR DESCRIPTION

![Uploading roadmap-desktop.png…]()
Closes #864

## What & why

Implements **issue #864 — Interactive Roadmap and Feature Requests**. Replaces the in-memory roadmap stub with a persistent, community-driven board where visitors can view the roadmap, upvote ideas, and submit their own feature requests.

All changes are confined to the `frontend/` directory.

## Acceptance criteria

- ✅ **Upvote functionality** — each card has an upvote toggle. Voting is **idempotent** (one vote per visitor, toggleable) and **persists** across reloads/tabs; the visitor's vote layers on top of the seeded community counts.
- ✅ **Status indicators (In Progress, Done)** — items are grouped into **Planned / In Progress / Done** columns, each with a colored status dot, a per-card status badge, and a live count.

## Deliverable + supporting files

- `src/app/roadmap/page.tsx` — the roadmap board (3 status columns, sorted by votes), upvote buttons with a "Voted" state, a **Community** badge on visitor submissions, and a **Submit feature request** dialog (`react-hook-form` + `zod`, 280-char description counter).
- `src/lib/roadmap.ts` — seeded roadmap + zod-validated request model + SSR-safe localStorage persistence.
- `src/hooks/use-roadmap.ts` — reactive store via `useSyncExternalStore`, persisted and synced across tabs.

## Notes

- Persistence uses localStorage (the frontend has no backend yet); the store is structured so swapping in a real API later is straightforward.
- Removed the stub's double-`<Navbar>` bug by following the app-page convention (the global layout already renders the navbar).

## Verified output

```
$ npx tsc --noEmit   → exit 0 (no type errors)
$ npx eslint <files> → 0 errors (1 benign react-hook-form warning)
$ npm run build      → ✓ Compiled successfully; /roadmap prerendered (○ Static)
```

## Screenshots

Functional screenshots (seeded state) captured via system Chrome — board with voted/unvoted states & status columns, the submit dialog, and mobile. _Drag the images into this description:_

- `roadmap-desktop.png`
- `roadmap-dialog.png`
- `roadmap-mobile.png`
