### PR TITLE
feat: #929 #930 #931 #932 — import resolver, ledger backup, telemetry benchmarks, sandbox docs

### DIFF
--- a/docs/guides/local-sandbox-setup.md
+++ b/docs/guides/local-sandbox-setup.md
@@ -1,0 +1,122 @@
+# Local Soroban Sandbox Environment
+
+Run a local Stellar/Soroban node with Docker and point the Stellar Suite IDE at `localhost` for offline-first contract development.
+
+## Overview
+
+```mermaid
+flowchart LR
+  IDE[Stellar Suite IDE] -->|JSON-RPC| RPC[Local Soroban RPC :8000]
+  IDE -->|Horizon REST| HZ[Horizon :8000]
+  RPC --> QS[Stellar Quickstart Docker]
+  HZ --> QS
+```
+
+## Prerequisites
+
+- Docker Engine 24+ with `docker compose` or `docker run`
+- Stellar Suite IDE (`ide/` package) running locally or deployed
+- A funded test keypair (Friendbot on local networks)
+
+## 1. Start the local sandbox (Quickstart)
+
+Pull and run the official Stellar Quickstart image in **local** mode:
+
+```bash
+docker run --rm -it \
+  -p 8000:8000 \
+  --name stellar-quickstart \
+  stellar/quickstart:latest \
+  --local --enable-soroban-rpc
+```
+
+Wait until the container logs show Horizon and Soroban RPC are ready (typically 30–90 seconds on first boot).
+
+Verify the RPC endpoint:
+
+```bash
+curl -s http://localhost:8000/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}' | jq .
+```
+
+Expected: a JSON-RPC response with `"status":"healthy"` (or equivalent) from the local node.
+
+### Optional: persist ledger data
+
+```bash
+docker volume create stellar-local-data
+
+docker run --rm -it \
+  -p 8000:8000 \
+  -v stellar-local-data:/opt/stellar \
+  --name stellar-quickstart \
+  stellar/quickstart:latest \
+  --local --enable-soroban-rpc
+```
+
+## 2. Fund a test account (Friendbot)
+
+```bash
+curl "http://localhost:8000/friendbot?addr=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+```
+
+Replace the `G…` address with your IDE identity public key.
+
+## 3. Point the IDE to localhost
+
+### Network preset
+
+1. Open **Settings → Network** (or the network selector in the status bar).
+2. Choose **Local**.
+3. Confirm defaults:
+   - **RPC URL:** `http://localhost:8000`
+   - **Horizon URL:** `http://localhost:8000`
+   - **Passphrase:** `Local Stellar Network`
+
+### Custom RPC (shared environments)
+
+If your team uses **Settings → Environment → Custom Networks**:
+
+| Field | Value |
+| --- | --- |
+| Label | `Local Sandbox` |
+| RPC URL | `http://localhost:8000` |
+| Passphrase | `Local Stellar Network` |
+
+Enable **Share with team** only when distributing a team-wide staging config; keep local sandboxes personal by default.
+
+### Environment variables (optional)
+
+For scripted deployments against the same node:
+
+```bash
+export STELLAR_RPC_URL=http://localhost:8000
+export STELLAR_NETWORK_PASSPHRASE="Local Stellar Network"
+```
+
+## 4. Validate in the IDE
+
+1. Build a sample contract (`hello_world` template).
+2. Deploy to the **Local** network.
+3. Run **Simulate** on a contract method — results should return without public testnet latency.
+4. Open **State Explorer** to inspect ledger keys after simulation.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `Network error: Unable to reach RPC` | Ensure Docker is running and port `8000` is not used by another service. |
+| CORS errors in the browser | Use the IDE on `localhost` or configure your reverse proxy to allow the IDE origin. |
+| Transactions fail with bad sequence | Reset the container or fund the account again via Friendbot. |
+| Slow first simulation | Quickstart may still be ingesting ledgers; wait for health check to pass. |
+
+## Security notes
+
+- The local Quickstart image is for **development only** — never expose port `8000` to the public internet without authentication.
+- Do not reuse mainnet secret keys on local sandboxes.
+
+## Related guides
+
+- [Simulation walkthrough](../tutorials/simulation-guide.md)
+- [Custom deployment](./custom-deployment.md)

--- a/ide/src/components/ide/LedgerBackup.tsx
+++ b/ide/src/components/ide/LedgerBackup.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Download, Upload } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  downloadLedgerBackup,
+  exportLedgerBackup,
+  parseLedgerBackup,
+} from "@/lib/ledgerBackup";
+import { useWorkspaceStore } from "@/store/workspaceStore";
+
+export function LedgerBackup() {
+  const mockLedgerState = useWorkspaceStore((s) => s.mockLedgerState);
+  const setMockLedgerState = useWorkspaceStore((s) => s.setMockLedgerState);
+  const clearMockLedgerState = useWorkspaceStore((s) => s.clearMockLedgerState);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [lastExportedAt, setLastExportedAt] = useState<string | null>(null);
+
+  const handleExport = () => {
+    try {
+      downloadLedgerBackup(mockLedgerState);
+      setLastExportedAt(new Date().toISOString());
+      toast.success(`Exported ${mockLedgerState.entries.length} ledger entries`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Export failed");
+    }
+  };
+
+  const handleCopyJson = async () => {
+    try {
+      await navigator.clipboard.writeText(exportLedgerBackup(mockLedgerState));
+      toast.success("Ledger backup JSON copied to clipboard");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Copy failed");
+    }
+  };
+
+  const handleImportFile = async (file: File) => {
+    try {
+      const text = await file.text();
+      const { state, exportedAt } = parseLedgerBackup(text);
+      setMockLedgerState(state);
+      setLastExportedAt(exportedAt);
+      toast.success(`Restored ${state.entries.length} ledger entries`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Import failed");
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+            Simulated Ledger Backup
+          </p>
+          <p className="text-[10px] text-muted-foreground mt-0.5">
+            {mockLedgerState.entries.length} entr
+            {mockLedgerState.entries.length === 1 ? "y" : "ies"} in memory
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 text-[10px]"
+            onClick={handleExport}
+          >
+            <Download className="h-3 w-3 mr-1" />
+            Export
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 text-[10px]"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload className="h-3 w-3 mr-1" />
+            Import
+          </Button>
+        </div>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void handleImportFile(file);
+          event.target.value = "";
+        }}
+      />
+
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-7 flex-1 text-[10px]"
+          onClick={() => void handleCopyJson()}
+        >
+          Copy JSON
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-7 flex-1 text-[10px] text-destructive hover:text-destructive"
+          onClick={() => {
+            clearMockLedgerState();
+            toast.message("Cleared simulated ledger state");
+          }}
+          disabled={mockLedgerState.entries.length === 0}
+        >
+          Clear
+        </Button>
+      </div>
+
+      {lastExportedAt && (
+        <p className="text-[10px] font-mono text-muted-foreground">
+          Last backup: {new Date(lastExportedAt).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ide/src/components/ide/StateExplorer.tsx
+++ b/ide/src/components/ide/StateExplorer.tsx
@@ -10,6 +10,7 @@ import {
   type LedgerEntry,
 } from "@/lib/sorobanRpc";
 import { useTransactionResultsStore } from "@/store/useTransactionResultsStore";
+import { LedgerBackup } from "@/components/ide/LedgerBackup";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Lightweight XDR / ScVal decoder
@@ -631,6 +632,10 @@ export function StateExplorer({ network, contractId: propContractId }: StateExpl
       )}
 
       <div className="flex-1 overflow-y-auto">
+        <div className="px-3 py-2 border-b border-sidebar-border">
+          <LedgerBackup />
+        </div>
+
         {/* ── XDR key input ──────────────────────────────────────────── */}
         <div className="px-3 py-2 border-b border-sidebar-border space-y-1.5">
           <div className="flex items-center justify-between">

--- a/ide/src/features/ide/Index.tsx
+++ b/ide/src/features/ide/Index.tsx
@@ -89,6 +89,8 @@ import { SimulationDiff } from "@/components/ide/SimulationDiff";
 import { InteractiveTour } from "@/components/ide/InteractiveTour";
 import { useNetworkStore } from "@/store/useNetworkStore";
 import { buildProtocolCompatibilityReport } from "@/lib/protocolUpgrade";
+import { resolveWorkspaceCompileFiles } from "@/lib/fs/UniversalResolver";
+import { recordSimulationTelemetry } from "@/lib/simulationTelemetry";
 
 const COMPILE_API_URL =
   process.env.NEXT_PUBLIC_COMPILE_API_URL ?? "/api/compile";
@@ -494,6 +496,11 @@ export default function Index() {
     [activeTabPath, contractName, files, network, selectedEnvironmentSlot],
   );
 
+  const resolveCompilePayloadFiles = useCallback(
+    () => resolveWorkspaceCompileFiles(flattenProjectFiles(files)),
+    [files],
+  );
+
   const handleCompile = useCallback(async () => {
     recordMonitoringBreadcrumb("ide.build", "Build started", {
       network,
@@ -529,9 +536,10 @@ export default function Index() {
     let wasCancelled = false;
 
     try {
+      const resolvedFiles = await resolveCompilePayloadFiles();
       const result = await workerCompile({
         url: COMPILE_API_URL,
-        payload: compilePayload,
+        payload: { ...compilePayload, files: resolvedFiles },
         onChunk: appendTerminalOutput,
         contractName,
         // Stream-parse diagnostics as chunks arrive so Monaco markers light up
@@ -615,7 +623,9 @@ export default function Index() {
     clearDiagnostics,
     compilePayload,
     contractName,
+    files,
     network,
+    resolveCompilePayloadFiles,
     selectedEnvironmentSlot,
     setBuildState,
     setDiagnostics,
@@ -630,15 +640,16 @@ export default function Index() {
     setTerminalExpanded(true);
     appendTerminalOutput("> Running cargo clippy --message-format=json\r\n");
 
-    try {
-      const response = await fetch("/api/clippy", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contractName,
-          files: compilePayload.files,
-        }),
-      });
+      try {
+        const resolvedFiles = await resolveCompilePayloadFiles();
+        const response = await fetch("/api/clippy", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contractName,
+            files: resolvedFiles,
+          }),
+        });
 
       const payload = (await response.json()) as {
         success?: boolean;
@@ -685,8 +696,8 @@ export default function Index() {
     }
   }, [
     appendTerminalOutput,
-    compilePayload.files,
     contractName,
+    resolveCompilePayloadFiles,
     setDiagnostics,
     setTerminalExpanded,
   ]);
@@ -697,15 +708,16 @@ export default function Index() {
     setTerminalExpanded(true);
     appendTerminalOutput("> Running cargo audit --json\r\n");
 
-    try {
-      const response = await fetch("/api/audit", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contractName,
-          files: compilePayload.files,
-        }),
-      });
+      try {
+        const resolvedFiles = await resolveCompilePayloadFiles();
+        const response = await fetch("/api/audit", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contractName,
+            files: resolvedFiles,
+          }),
+        });
 
       const payload = (await response.json()) as {
         success?: boolean;
@@ -748,8 +760,8 @@ export default function Index() {
     }
   }, [
     appendTerminalOutput,
-    compilePayload.files,
     contractName,
+    resolveCompilePayloadFiles,
     setTerminalExpanded,
   ]);
 
@@ -1105,12 +1117,13 @@ export default function Index() {
       }
 
       try {
+        const resolvedFiles = await resolveCompilePayloadFiles();
         const response = await fetch("/api/run-test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             contractName,
-            files: compilePayload.files,
+            files: resolvedFiles,
             mode: "full",
             integrationTargets,
           }),
@@ -1163,10 +1176,10 @@ export default function Index() {
   }, [
     activeTabPath,
     appendTerminalOutput,
-    compilePayload.files,
     contractName,
     files,
     mockLedgerState,
+    resolveCompilePayloadFiles,
     setTerminalExpanded,
     setTerminalOutput,
   ]);
@@ -1186,12 +1199,13 @@ export default function Index() {
       const integrationTargets = listIntegrationTargets(discoveredTests);
 
       try {
+        const resolvedFiles = await resolveCompilePayloadFiles();
         const response = await fetch("/api/run-test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             contractName,
-            files: compilePayload.files,
+            files: resolvedFiles,
             mode: "failed-only",
             failedTestNames,
             integrationTargets,
@@ -1249,9 +1263,9 @@ export default function Index() {
     })();
   }, [
     activeTabPath,
-    compilePayload.files,
     contractName,
     files,
+    resolveCompilePayloadFiles,
     setTerminalExpanded,
     setTerminalOutput,
     testRun,
@@ -1411,11 +1425,22 @@ export default function Index() {
             })
           : null;
 
+        const simulationTxId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${fn}`;
+
+        recordSimulationTelemetry({
+          transactionId: simulationTxId,
+          contractId,
+          functionName: fn,
+          durationMs: Date.now() - startedAt,
+          success: true,
+          ledgerKeyCount: simulationComparison?.summary.total,
+        });
+
         appendTransactionLog({
-          id:
-            typeof crypto !== "undefined" && "randomUUID" in crypto
-              ? crypto.randomUUID()
-              : `${Date.now()}-${fn}`,
+          id: simulationTxId,
           timestamp: new Date().toISOString(),
           network,
           contractId,

--- a/ide/src/lib/__tests__/ledgerBackup.test.ts
+++ b/ide/src/lib/__tests__/ledgerBackup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  exportLedgerBackup,
+  LEDGER_BACKUP_VERSION,
+  parseLedgerBackup,
+} from "@/lib/ledgerBackup";
+
+describe("ledgerBackup", () => {
+  const sampleState = {
+    entries: [
+      {
+        id: "entry-1",
+        type: "contractData" as const,
+        key: "balance",
+        value: "1000",
+      },
+    ],
+  };
+
+  it("exports and parses a valid backup", () => {
+    const json = exportLedgerBackup(sampleState);
+    const parsed = parseLedgerBackup(json);
+
+    expect(parsed.state).toEqual(sampleState);
+    expect(parsed.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("rejects invalid schema", () => {
+    expect(() =>
+      parseLedgerBackup(
+        JSON.stringify({
+          version: LEDGER_BACKUP_VERSION,
+          exportedAt: new Date().toISOString(),
+          mockLedgerState: { entries: [{ id: "", type: "bad", key: "", value: "" }] },
+        }),
+      ),
+    ).toThrow(/schema validation failed/i);
+  });
+});

--- a/ide/src/lib/fs/UniversalResolver.ts
+++ b/ide/src/lib/fs/UniversalResolver.ts
@@ -1,0 +1,167 @@
+/**
+ * Resolves workspace-relative paths and remote https:// imports for compile payloads.
+ * Remote files are cached in IndexedDB for faster subsequent loads.
+ */
+
+const REMOTE_IMPORT_DB = "stellar-suite-remote-imports";
+const REMOTE_IMPORT_STORE = "files";
+const REMOTE_IMPORT_DB_VERSION = 1;
+
+const HTTPS_IMPORT_RE =
+  /(?:use\s+[\w:]+(?:\s*::\s*[\w:]+)*\s*=\s*|mod\s+|#\[path\s*=\s*)["'](https?:\/\/[^"']+)["']/g;
+
+export interface ResolvedRemoteFile {
+  url: string;
+  content: string;
+  fromCache: boolean;
+  virtualPath: string;
+}
+
+export interface WorkspaceCompileFile {
+  path: string;
+  content: string;
+  language?: string;
+}
+
+function openRemoteImportDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(REMOTE_IMPORT_DB, REMOTE_IMPORT_DB_VERSION);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(REMOTE_IMPORT_STORE)) {
+        req.result.createObjectStore(REMOTE_IMPORT_STORE);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export function isRemoteImport(specifier: string): boolean {
+  return /^https?:\/\//i.test(specifier.trim());
+}
+
+/** Sanitize a remote URL into a stable IndexedDB cache key. */
+export function sanitizeRemoteCacheKey(url: string): string {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Unsupported remote protocol: ${parsed.protocol}`);
+  }
+  return `${parsed.protocol}//${parsed.host}${parsed.pathname}${parsed.search}`;
+}
+
+/** Map a remote URL to a virtual workspace path for the compiler payload. */
+export function remoteUrlToVirtualPath(url: string): string {
+  const parsed = new URL(url);
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  const fileName = segments.pop() ?? "remote.rs";
+  const hostDir = parsed.hostname.replace(/\./g, "_");
+  return `remote/${hostDir}/${segments.join("_") || "root"}/${fileName}`;
+}
+
+export function extractRemoteImportUrls(content: string): string[] {
+  const urls = new Set<string>();
+  for (const match of content.matchAll(HTTPS_IMPORT_RE)) {
+    const url = match[1];
+    if (url) urls.add(url);
+  }
+  return [...urls];
+}
+
+async function readCachedRemote(url: string): Promise<string | null> {
+  if (typeof indexedDB === "undefined") return null;
+  const key = sanitizeRemoteCacheKey(url);
+  const db = await openRemoteImportDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(REMOTE_IMPORT_STORE, "readonly");
+    const req = tx.objectStore(REMOTE_IMPORT_STORE).get(key);
+    req.onsuccess = () => resolve(typeof req.result === "string" ? req.result : null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function writeCachedRemote(url: string, content: string): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  const key = sanitizeRemoteCacheKey(url);
+  const db = await openRemoteImportDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(REMOTE_IMPORT_STORE, "readwrite");
+    tx.objectStore(REMOTE_IMPORT_STORE).put(content, key);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function resolveRemoteImport(url: string): Promise<ResolvedRemoteFile> {
+  if (!isRemoteImport(url)) {
+    throw new Error(`Not a remote import URL: ${url}`);
+  }
+
+  const cached = await readCachedRemote(url);
+  if (cached !== null) {
+    return {
+      url,
+      content: cached,
+      fromCache: true,
+      virtualPath: remoteUrlToVirtualPath(url),
+    };
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "text/plain, application/octet-stream, */*" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote import (${response.status}): ${url}`);
+  }
+
+  const content = await response.text();
+  await writeCachedRemote(url, content);
+
+  return {
+    url,
+    content,
+    fromCache: false,
+    virtualPath: remoteUrlToVirtualPath(url),
+  };
+}
+
+/**
+ * Expand compile files with any https:// dependencies referenced in source.
+ */
+export async function resolveWorkspaceCompileFiles(
+  files: WorkspaceCompileFile[],
+): Promise<WorkspaceCompileFile[]> {
+  const byPath = new Map(files.map((file) => [file.path, { ...file }]));
+  const pendingUrls = new Set<string>();
+
+  for (const file of files) {
+    for (const url of extractRemoteImportUrls(file.content)) {
+      pendingUrls.add(url);
+    }
+  }
+
+  for (const url of pendingUrls) {
+    const resolved = await resolveRemoteImport(url);
+    if (!byPath.has(resolved.virtualPath)) {
+      byPath.set(resolved.virtualPath, {
+        path: resolved.virtualPath,
+        content: resolved.content,
+        language: "rust",
+      });
+    }
+  }
+
+  return [...byPath.values()];
+}
+
+export class UniversalResolver {
+  async resolve(specifier: string): Promise<ResolvedRemoteFile | null> {
+    if (!isRemoteImport(specifier)) return null;
+    return resolveRemoteImport(specifier);
+  }
+
+  async resolveWorkspaceFiles(files: WorkspaceCompileFile[]): Promise<WorkspaceCompileFile[]> {
+    return resolveWorkspaceCompileFiles(files);
+  }
+}

--- a/ide/src/lib/fs/__tests__/UniversalResolver.test.ts
+++ b/ide/src/lib/fs/__tests__/UniversalResolver.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  extractRemoteImportUrls,
+  isRemoteImport,
+  remoteUrlToVirtualPath,
+  resolveRemoteImport,
+  resolveWorkspaceCompileFiles,
+  sanitizeRemoteCacheKey,
+} from "@/lib/fs/UniversalResolver";
+
+describe("UniversalResolver", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("detects remote import specifiers", () => {
+    expect(isRemoteImport("https://example.com/lib.rs")).toBe(true);
+    expect(isRemoteImport("./local/mod.rs")).toBe(false);
+  });
+
+  it("extracts https URLs from Rust source", () => {
+    const source = `
+      use remote_crate::Thing = "https://example.com/crates/thing.rs";
+      mod helper;
+    `;
+    expect(extractRemoteImportUrls(source)).toEqual([
+      "https://example.com/crates/thing.rs",
+    ]);
+  });
+
+  it("sanitizes cache keys and virtual paths", () => {
+    const url = "https://example.com/path/to/file.rs?ref=main";
+    expect(sanitizeRemoteCacheKey(url)).toBe(
+      "https://example.com/path/to/file.rs?ref=main",
+    );
+    expect(remoteUrlToVirtualPath(url)).toBe("remote/example_com/path_to/file.rs");
+  });
+
+  it("fetches remote imports and caches them", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => "pub fn remote_fn() {}",
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const first = await resolveRemoteImport("https://example.com/remote.rs");
+    expect(first.fromCache).toBe(false);
+    expect(first.content).toContain("remote_fn");
+
+    const second = await resolveRemoteImport("https://example.com/remote.rs");
+    expect(second.fromCache).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands workspace compile files with remote dependencies", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "pub mod imported {}",
+      }),
+    );
+
+    const expanded = await resolveWorkspaceCompileFiles([
+      {
+        path: "src/lib.rs",
+        content: 'use dep = "https://example.com/dep.rs";',
+        language: "rust",
+      },
+    ]);
+
+    expect(expanded.length).toBe(2);
+    expect(expanded.some((f) => f.path.includes("remote/example_com"))).toBe(true);
+  });
+});

--- a/ide/src/lib/ledgerBackup.ts
+++ b/ide/src/lib/ledgerBackup.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+import type { MockLedgerState } from "@/store/workspaceStore";
+
+export const LEDGER_BACKUP_VERSION = 1 as const;
+
+const mockLedgerEntrySchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["account", "contractData", "tokenBalance"]),
+  key: z.string(),
+  value: z.string(),
+  metadata: z.record(z.string()).optional(),
+});
+
+const ledgerBackupSchema = z.object({
+  version: z.literal(LEDGER_BACKUP_VERSION),
+  exportedAt: z.string().datetime(),
+  mockLedgerState: z.object({
+    entries: z.array(mockLedgerEntrySchema),
+  }),
+});
+
+export type LedgerBackupPayload = z.infer<typeof ledgerBackupSchema>;
+
+export function exportLedgerBackup(state: MockLedgerState): string {
+  const payload: LedgerBackupPayload = {
+    version: LEDGER_BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    mockLedgerState: state,
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export function parseLedgerBackup(
+  json: string,
+): { state: MockLedgerState; exportedAt: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Ledger backup file is not valid JSON.");
+  }
+
+  const result = ledgerBackupSchema.safeParse(parsed);
+  if (!result.success) {
+    const detail = result.error.issues.map((i) => i.message).join("; ");
+    throw new Error(`Ledger backup schema validation failed: ${detail}`);
+  }
+
+  return {
+    state: result.data.mockLedgerState,
+    exportedAt: result.data.exportedAt,
+  };
+}
+
+export function downloadLedgerBackup(
+  state: MockLedgerState,
+  filename = "ledger-backup.json",
+): void {
+  const blob = new Blob([exportLedgerBackup(state)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/ide/src/lib/simulationTelemetry.ts
+++ b/ide/src/lib/simulationTelemetry.ts
@@ -1,0 +1,70 @@
+/**
+ * Lightweight simulation telemetry for the IDE runner loop.
+ * Disabled mode is a no-op so benchmarks can measure overhead in isolation.
+ */
+
+export interface SimulationTelemetryEvent {
+  transactionId: string;
+  contractId: string;
+  functionName: string;
+  durationMs: number;
+  success: boolean;
+  ledgerKeyCount?: number;
+}
+
+let enabled = true;
+const buffer: SimulationTelemetryEvent[] = [];
+const MAX_BUFFER = 256;
+
+export function setSimulationTelemetryEnabled(value: boolean): void {
+  enabled = value;
+}
+
+export function isSimulationTelemetryEnabled(): boolean {
+  return enabled;
+}
+
+export function recordSimulationTelemetry(event: SimulationTelemetryEvent): void {
+  if (!enabled) return;
+  buffer.push(event);
+  if (buffer.length > MAX_BUFFER) {
+    buffer.shift();
+  }
+}
+
+export function getSimulationTelemetryBuffer(): readonly SimulationTelemetryEvent[] {
+  return buffer;
+}
+
+export function clearSimulationTelemetryBuffer(): void {
+  buffer.length = 0;
+}
+
+/** Minimal runner-loop step used by benchmarks and simulation flows. */
+export function runSimulationRunnerStep(payload: {
+  contractId: string;
+  fn: string;
+  argsHash: number;
+}): { ok: boolean; resultHash: number } {
+  let hash = payload.argsHash;
+  for (let i = 0; i < 8; i++) {
+    hash = (hash * 31 + payload.fn.charCodeAt(i % payload.fn.length)) | 0;
+  }
+  return { ok: true, resultHash: hash ^ payload.contractId.length };
+}
+
+export function runSimulationRunnerStepWithTelemetry(
+  payload: { contractId: string; fn: string; argsHash: number },
+  transactionId: string,
+): { ok: boolean; resultHash: number } {
+  const started = performance.now();
+  const result = runSimulationRunnerStep(payload);
+  recordSimulationTelemetry({
+    transactionId,
+    contractId: payload.contractId,
+    functionName: payload.fn,
+    durationMs: performance.now() - started,
+    success: result.ok,
+  });
+  return result;
+}

--- a/ide/src/test/benchmarks/telemetry.bench.ts
+++ b/ide/src/test/benchmarks/telemetry.bench.ts
@@ -1,0 +1,61 @@
+import { bench, describe, expect } from "vitest";
+
+import {
+  clearSimulationTelemetryBuffer,
+  runSimulationRunnerStep,
+  runSimulationRunnerStepWithTelemetry,
+  setSimulationTelemetryEnabled,
+} from "@/lib/simulationTelemetry";
+
+const TX_COUNT = 200;
+const MAX_OVERHEAD_MS_PER_TX = 2;
+
+function buildPayloads(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    contractId: `C${(i % 7).toString(16).repeat(8)}`,
+    fn: `invoke_${i % 12}`,
+    argsHash: i * 9973,
+  }));
+}
+
+const payloads = buildPayloads(TX_COUNT);
+
+describe("simulation telemetry overhead", () => {
+  bench("runner loop — telemetry disabled", () => {
+    setSimulationTelemetryEnabled(false);
+    clearSimulationTelemetryBuffer();
+
+    for (let i = 0; i < TX_COUNT; i++) {
+      runSimulationRunnerStep(payloads[i]);
+    }
+  });
+
+  bench("runner loop — telemetry enabled", () => {
+    setSimulationTelemetryEnabled(true);
+    clearSimulationTelemetryBuffer();
+
+    for (let i = 0; i < TX_COUNT; i++) {
+      runSimulationRunnerStepWithTelemetry(payloads[i], `tx-${i}`);
+    }
+  });
+
+  bench("per-transaction overhead budget (<2ms)", () => {
+    setSimulationTelemetryEnabled(false);
+    const baselineStart = performance.now();
+    for (let i = 0; i < TX_COUNT; i++) {
+      runSimulationRunnerStep(payloads[i]);
+    }
+    const baselineMs = performance.now() - baselineStart;
+
+    setSimulationTelemetryEnabled(true);
+    clearSimulationTelemetryBuffer();
+    const telemetryStart = performance.now();
+    for (let i = 0; i < TX_COUNT; i++) {
+      runSimulationRunnerStepWithTelemetry(payloads[i], `budget-${i}`);
+    }
+    const telemetryMs = performance.now() - telemetryStart;
+
+    const overheadPerTx = (telemetryMs - baselineMs) / TX_COUNT;
+    expect(overheadPerTx).toBeLessThan(MAX_OVERHEAD_MS_PER_TX);
+  });
+});

--- a/ide/src/test/benchmarks/xdr.bench.ts
+++ b/ide/src/test/benchmarks/xdr.bench.ts
@@ -1,4 +1,4 @@
-import { describe, bench } from "vitest";
+import { describe, bench, expect } from "vitest";
 import { xdr } from "@stellar/stellar-sdk";
 import {
   filterByKeyType,
@@ -7,6 +7,15 @@ import {
   transformLedgerEntry,
   type DecodedLedgerEntry,
 } from "@/lib/scvalTransformer";
+import {
+  decodeFromXdr,
+  decodeMap,
+  decodeVec,
+  encodeMap,
+  encodeToXdr,
+  encodeVec,
+} from "@/utils/XdrUtils";
+import { buildSimulationComparison } from "@/lib/simulationDiff";
 
 // Pre-built XDR fixtures — constructed once so construction cost is excluded from bench loops
 const XDR_VOID = xdr.ScVal.scvVoid().toXDR("base64");
@@ -202,17 +211,7 @@ describe("state diff — 1 000 entries (10 % mutation)", () => {
   bench("diffEntries identical snapshots", () => {
     diffEntries(ENTRIES_1000, ENTRIES_1000);
   });
-import { bench, describe, expect } from "vitest";
-
-import {
-  decodeFromXdr,
-  decodeMap,
-  decodeVec,
-  encodeMap,
-  encodeToXdr,
-  encodeVec,
-} from "@/utils/XdrUtils";
-import { buildSimulationComparison } from "@/lib/simulationDiff";
+});
 
 const createLargeMapPayload = (size: number) => {
   const payload: Record<string, unknown> = {};

--- a/ide/vitest.config.ts
+++ b/ide/vitest.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
     benchmark: {
       include: ["src/**/*.bench.ts"],
+    },
     include: [
       "src/**/*.{test,spec}.{ts,tsx}",
       "tests/**/*.{test,spec}.{ts,tsx}",


### PR DESCRIPTION
## Summary

Closes #929, closes #930, closes #931, closes #932 in a single focused PR.

- **#929 Universal File Import Resolver** — `ide/src/lib/fs/UniversalResolver.ts` resolves `https://` Rust imports, caches payloads in IndexedDB, and expands compile/test/clippy/audit payloads before API calls.
- **#930 Ledger State Back-restore** — `ide/src/lib/ledgerBackup.ts` + `ide/src/components/ide/LedgerBackup.tsx` export/import simulated `mockLedgerState` as versioned JSON (Zod-validated), integrated in State Explorer.
- **#931 Simulation Telemetry Benchmarks** — `ide/src/lib/simulationTelemetry.ts` lightweight runner telemetry + `ide/src/test/benchmarks/telemetry.bench.ts` comparing disabled vs enabled overhead (budget **< 2ms per transaction**).
- **#932 Local Soroban Sandbox Guide** — `docs/guides/local-sandbox-setup.md` with Docker Quickstart commands and IDE localhost network configuration.

Also fixes a corrupted `xdr.bench.ts` block and duplicate `include` key in `vitest.config.ts`.

## Test plan

- [x] `npm test -- src/lib/__tests__/ledgerBackup.test.ts src/lib/fs/__tests__/UniversalResolver.test.ts`
- [x] `npm run test:bench -- src/test/benchmarks/telemetry.bench.ts` (per-transaction overhead guard passes)
- [ ] Manual: State Explorer → Export / Import ledger JSON
- [ ] Manual: add `use dep = "https://…/file.rs";` in a contract and run **Build**
- [ ] Manual: follow `docs/guides/local-sandbox-setup.md` against local Quickstart

## Verification output

```
✓ src/lib/__tests__/ledgerBackup.test.ts (2 tests)
✓ src/lib/fs/__tests__/UniversalResolver.test.ts (5 tests)

telemetry.bench.ts:
  · runner loop — telemetry disabled
  · runner loop — telemetry enabled
  · per-transaction overhead budget (<2ms)  ✓
```
