### PR TITLE
feat(ide): implement issues #815, #816, #837, #840

### DIFF
--- a/ide/src/components/ide/EditorTabs.tsx
+++ b/ide/src/components/ide/EditorTabs.tsx
@@ -9,7 +9,7 @@ import {
   Settings,
   X,
 } from "lucide-react";
-import { KeyboardEvent, useRef, useCallback } from "react";
+import { KeyboardEvent, useRef, useCallback, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,9 +81,11 @@ function FileIcon({ name }: { name: string }) {
 // ---------------------------------------------------------------------------
 
 export function EditorTabs({ onTabSelect, onTabClose }: EditorTabsProps) {
-  const { openTabs, activeTabPath, setActiveTabPath, closeTab, unsavedFiles } =
+  const { openTabs, activeTabPath, setActiveTabPath, closeTab, unsavedFiles, setOpenTabs } =
     useWorkspaceStore();
   const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+  const dragIndexRef = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const tabsWithStatus = openTabs.map((t) => ({
     ...t,
@@ -122,6 +124,32 @@ export function EditorTabs({ onTabSelect, onTabClose }: EditorTabsProps) {
     [tabsWithStatus, onTabSelect, onTabClose, setActiveTabPath, closeTab],
   );
 
+  const handleTabDragStart = useCallback((index: number) => {
+    dragIndexRef.current = index;
+  }, []);
+
+  const handleTabDragOver = useCallback((e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  }, []);
+
+  const handleTabDrop = useCallback((toIndex: number) => {
+    const fromIndex = dragIndexRef.current;
+    if (fromIndex !== null && fromIndex !== toIndex) {
+      const next = [...openTabs];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      setOpenTabs(next);
+    }
+    dragIndexRef.current = null;
+    setDragOverIndex(null);
+  }, [openTabs, setOpenTabs]);
+
+  const handleTabDragEnd = useCallback(() => {
+    dragIndexRef.current = null;
+    setDragOverIndex(null);
+  }, []);
+
   if (tabsWithStatus.length === 0) {
     return (
       <div
@@ -135,79 +163,79 @@ export function EditorTabs({ onTabSelect, onTabClose }: EditorTabsProps) {
     <div
       role="tablist"
       aria-label="Open editor tabs"
-      className="flex bg-secondary border-b border-border overflow-x-auto scrollbar-none"
+      className="flex bg-secondary border-b border-border overflow-x-auto scrollbar-none ide-tab-bar"
     >
-      {tabsWithStatus.map((tab) => {
+      {tabsWithStatus.map((tab, index) => {
         const key = tab.path.join("/");
         const isActive = key === activeTabKey;
         const isDirty = tab.unsaved;
 
         return (
-          <button
+          <div
             key={key}
-            ref={(el) => {
-              if (el) tabRefs.current.set(key, el);
-              else tabRefs.current.delete(key);
-            }}
-            role="tab"
-            aria-selected={isActive}
-            aria-label={`${tab.name}${isDirty ? " (unsaved)" : ""}`}
-            tabIndex={isActive ? 0 : -1}
-            className={`group flex items-center gap-1.5 px-2.5 md:px-3 py-1.5 md:py-2 text-[11px] md:text-xs font-mono border-r border-border transition-colors min-w-0 shrink-0 outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary/60 ${
-              isActive
-                ? "bg-tab-active text-foreground border-t-2 border-t-primary"
-                : "bg-tab-inactive text-muted-foreground hover:bg-tab-hover border-t-2 border-t-transparent"
+            draggable
+            onDragStart={() => handleTabDragStart(index)}
+            onDragOver={(e) => handleTabDragOver(e, index)}
+            onDrop={() => handleTabDrop(index)}
+            onDragEnd={handleTabDragEnd}
+            className={`shrink-0 transition-all ${
+              dragOverIndex === index ? "ring-1 ring-inset ring-primary/50" : ""
             }`}
-            onClick={() => {
-              if (onTabSelect) onTabSelect(tab.path);
-              else setActiveTabPath(tab.path);
-            }}
-            onKeyDown={(e) => handleKeyDown(e, tab.path)}
           >
-            {/* File type icon */}
-            <FileIcon name={tab.name} />
-
-            {/* Filename */}
-            <span className="truncate max-w-[80px] md:max-w-[120px]">
-              {tab.name}
-            </span>
-
-            {/*
-              Dirty indicator / close button:
-              - When dirty: show filled dot; on hover swap to X
-              - When clean: show X only on hover
-            */}
-            <span
-              role="button"
-              aria-label={`Close ${tab.name}`}
-              className="shrink-0 rounded p-0.5 transition-opacity"
-              onClick={(e) => {
-                e.stopPropagation();
-                if (onTabClose) onTabClose(tab.path);
-                else closeTab(tab.path);
+            <button
+              ref={(el) => {
+                if (el) tabRefs.current.set(key, el);
+                else tabRefs.current.delete(key);
               }}
+              role="tab"
+              aria-selected={isActive}
+              aria-label={`${tab.name}${isDirty ? " (unsaved)" : ""}`}
+              tabIndex={isActive ? 0 : -1}
+              className={`group flex items-center gap-1.5 px-2.5 md:px-3 py-1.5 md:py-2 text-[11px] md:text-xs font-mono border-r border-border transition-colors min-w-0 shrink-0 outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-primary/60 cursor-grab active:cursor-grabbing ide-tab ${
+                isActive
+                  ? "bg-tab-active text-foreground border-t-2 border-t-primary"
+                  : "bg-tab-inactive text-muted-foreground hover:bg-tab-hover border-t-2 border-t-transparent"
+              }`}
+              onClick={() => {
+                if (onTabSelect) onTabSelect(tab.path);
+                else setActiveTabPath(tab.path);
+              }}
+              onKeyDown={(e) => handleKeyDown(e, tab.path)}
             >
-              {isDirty ? (
-                <>
-                  {/* Dot visible by default, hidden on group hover */}
-                  <Circle
-                    className="h-2 w-2 fill-primary text-primary group-hover:hidden"
-                    aria-hidden="true"
-                  />
-                  {/* X hidden by default, shown on group hover */}
+              <FileIcon name={tab.name} />
+              <span className="truncate max-w-[80px] md:max-w-[120px]">
+                {tab.name}
+              </span>
+              <span
+                role="button"
+                aria-label={`Close ${tab.name}`}
+                className="shrink-0 rounded p-0.5 transition-opacity"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (onTabClose) onTabClose(tab.path);
+                  else closeTab(tab.path);
+                }}
+              >
+                {isDirty ? (
+                  <>
+                    <Circle
+                      className="h-2 w-2 fill-primary text-primary group-hover:hidden"
+                      aria-hidden="true"
+                    />
+                    <X
+                      className="h-3 w-3 hidden group-hover:block"
+                      aria-hidden="true"
+                    />
+                  </>
+                ) : (
                   <X
-                    className="h-3 w-3 hidden group-hover:block"
+                    className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity"
                     aria-hidden="true"
                   />
-                </>
-              ) : (
-                <X
-                  className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity"
-                  aria-hidden="true"
-                />
-              )}
-            </span>
-          </button>
+                )}
+              </span>
+            </button>
+          </div>
         );
       })}
     </div>

--- a/ide/src/components/ide/InvocationSnapshotPanel.tsx
+++ b/ide/src/components/ide/InvocationSnapshotPanel.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+/**
+ * InvocationSnapshotPanel.tsx
+ * UI for automated snapshot verification of contract invocations — Issue #840
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Camera,
+  Play,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  Trash2,
+  RefreshCw,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { interactionRecorder, type RecordingSession } from "@/lib/testing/interactionRecorder";
+import {
+  recordSessionSnapshots,
+  verifySessionAgainstSnapshots,
+  getSessionsWithSnapshots,
+  clearSessionSnapshots,
+  type SessionVerificationReport,
+  type VerificationResult,
+} from "@/lib/testing/invocationSnapshotVerifier";
+
+// ─── Result row ───────────────────────────────────────────────────────────────
+
+function ResultRow({ result }: { result: VerificationResult }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDiffs = result.diffs && result.diffs.length > 0;
+
+  return (
+    <div className="rounded border border-border bg-card/30 overflow-hidden">
+      <button
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/30 transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        {result.error ? (
+          <AlertCircle className="h-3.5 w-3.5 text-yellow-400 shrink-0" />
+        ) : result.passed ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
+        ) : (
+          <XCircle className="h-3.5 w-3.5 text-destructive shrink-0" />
+        )}
+        <span className="flex-1 text-[11px] font-mono truncate">
+          {result.functionName}({result.args})
+        </span>
+        <span className="text-[9px] font-mono text-muted-foreground shrink-0">
+          {result.contractId.slice(0, 8)}…
+        </span>
+        {(hasDiffs || result.error) &&
+          (expanded ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
+          ))}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-2 space-y-1.5 border-t border-border/50">
+          {result.error && (
+            <p className="text-[10px] text-yellow-400 font-mono mt-1.5">{result.error}</p>
+          )}
+          {hasDiffs &&
+            result.diffs!.map((diff, i) => (
+              <div key={i} className="text-[10px] font-mono space-y-0.5 mt-1.5">
+                <p className="text-muted-foreground uppercase tracking-wider text-[9px]">
+                  {diff.type} @ {diff.path}
+                </p>
+                <p className="text-emerald-400">
+                  expected: {JSON.stringify(diff.oldValue)}
+                </p>
+                <p className="text-destructive">
+                  received: {JSON.stringify(diff.newValue)}
+                </p>
+              </div>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Report summary ───────────────────────────────────────────────────────────
+
+function ReportSummary({ report }: { report: SessionVerificationReport }) {
+  return (
+    <div className="rounded-lg border border-border bg-card/50 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-semibold text-foreground truncate">
+          {report.sessionName}
+        </span>
+        <span className="text-[9px] text-muted-foreground shrink-0">
+          {new Date(report.ranAt).toLocaleTimeString()}
+        </span>
+      </div>
+      <div className="flex gap-3 text-[10px]">
+        <span className="text-emerald-400">{report.passed} passed</span>
+        <span className="text-destructive">{report.failed} failed</span>
+        {report.errors > 0 && (
+          <span className="text-yellow-400">{report.errors} errors</span>
+        )}
+        <span className="text-muted-foreground ml-auto">
+          {report.totalInteractions} total
+        </span>
+      </div>
+      <div className="space-y-1 max-h-48 overflow-y-auto">
+        {report.results.map((r) => (
+          <ResultRow key={r.interactionId} result={r} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main panel ───────────────────────────────────────────────────────────────
+
+export function InvocationSnapshotPanel() {
+  const [sessions, setSessions] = useState<RecordingSession[]>([]);
+  const [baselineSessions, setBaselineSessions] = useState<string[]>([]);
+  const [selectedBaseline, setSelectedBaseline] = useState<string>("");
+  const [selectedReplay, setSelectedReplay] = useState<string>("");
+  const [report, setReport] = useState<SessionVerificationReport | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const [allSessions, withSnapshots] = await Promise.all([
+      interactionRecorder.getAllSessions(),
+      getSessionsWithSnapshots(),
+    ]);
+    setSessions(allSessions);
+    setBaselineSessions(withSnapshots);
+    setIsRecording(interactionRecorder.getRecordingStatus());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleRecordBaseline = async (sessionId: string) => {
+    const session = sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    try {
+      const count = await recordSessionSnapshots(session);
+      toast.success(`Recorded ${count} snapshot(s) as baseline`);
+      await refresh();
+    } catch (err) {
+      toast.error(`Failed to record baseline: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const handleRunVerification = async () => {
+    if (!selectedBaseline || !selectedReplay) {
+      toast.error("Select both a baseline and a replay session");
+      return;
+    }
+    const replaySession = sessions.find((s) => s.id === selectedReplay);
+    if (!replaySession) return;
+
+    setIsRunning(true);
+    try {
+      const result = await verifySessionAgainstSnapshots(replaySession, selectedBaseline);
+      setReport(result);
+      if (result.failed === 0 && result.errors === 0) {
+        toast.success(`All ${result.passed} invocations matched snapshots`);
+      } else {
+        toast.error(`${result.failed} mismatch(es), ${result.errors} error(s)`);
+      }
+    } catch (err) {
+      toast.error(`Verification failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const handleClearBaseline = async (sessionId: string) => {
+    await clearSessionSnapshots(sessionId);
+    toast.success("Baseline snapshots cleared");
+    await refresh();
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-sidebar overflow-hidden" data-testid="invocation-snapshot-panel">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-sidebar-border px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <Camera className="h-3.5 w-3.5 text-primary" />
+          <span className="text-xs font-semibold text-foreground">Snapshot Verification</span>
+        </div>
+        <button
+          onClick={refresh}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          aria-label="Refresh sessions"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-3">
+        {/* Baseline section */}
+        <div className="space-y-1.5">
+          <p className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Baseline Session
+          </p>
+          <p className="text-[9px] text-muted-foreground">
+            Record a golden session as the expected output baseline.
+          </p>
+          <select
+            value={selectedBaseline}
+            onChange={(e) => setSelectedBaseline(e.target.value)}
+            className="w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            aria-label="Select baseline session"
+          >
+            <option value="">— select session —</option>
+            {sessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+                {baselineSessions.includes(s.id) ? " ✓" : ""}
+              </option>
+            ))}
+          </select>
+          <div className="flex gap-1.5">
+            <button
+              onClick={() => selectedBaseline && handleRecordBaseline(selectedBaseline)}
+              disabled={!selectedBaseline}
+              className={cn(
+                "flex-1 flex items-center justify-center gap-1 rounded py-1.5 text-[10px] font-medium transition-colors",
+                selectedBaseline
+                  ? "bg-primary/15 text-primary hover:bg-primary/25"
+                  : "bg-muted/20 text-muted-foreground cursor-not-allowed"
+              )}
+              data-testid="record-baseline-btn"
+            >
+              <Camera className="h-3 w-3" />
+              Record as Baseline
+            </button>
+            {selectedBaseline && baselineSessions.includes(selectedBaseline) && (
+              <button
+                onClick={() => handleClearBaseline(selectedBaseline)}
+                className="rounded px-2 py-1.5 text-[10px] text-muted-foreground hover:text-destructive transition-colors"
+                aria-label="Clear baseline"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Replay section */}
+        <div className="space-y-1.5">
+          <p className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Replay Session
+          </p>
+          <p className="text-[9px] text-muted-foreground">
+            Select a session to verify against the baseline.
+          </p>
+          <select
+            value={selectedReplay}
+            onChange={(e) => setSelectedReplay(e.target.value)}
+            className="w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            aria-label="Select replay session"
+          >
+            <option value="">— select session —</option>
+            {sessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleRunVerification}
+            disabled={!selectedBaseline || !selectedReplay || isRunning}
+            className={cn(
+              "w-full flex items-center justify-center gap-1.5 rounded py-1.5 text-[10px] font-bold transition-colors",
+              selectedBaseline && selectedReplay && !isRunning
+                ? "bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25"
+                : "bg-muted/20 text-muted-foreground cursor-not-allowed"
+            )}
+            data-testid="run-verification-btn"
+          >
+            {isRunning ? (
+              <RefreshCw className="h-3 w-3 animate-spin" />
+            ) : (
+              <Play className="h-3 w-3" />
+            )}
+            {isRunning ? "Verifying…" : "Run Verification"}
+          </button>
+        </div>
+
+        {/* Report */}
+        {report && (
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Last Report
+            </p>
+            <ReportSummary report={report} />
+          </div>
+        )}
+
+        {/* Empty state */}
+        {sessions.length === 0 && (
+          <p className="text-[10px] text-muted-foreground italic text-center py-4">
+            No recorded sessions found. Use the Interaction Recorder to capture invocations.
+          </p>
+        )}
+      </div>
+
+      <div className="border-t border-sidebar-border px-3 py-2 text-[9px] text-muted-foreground">
+        Record a golden session, then replay to verify contract outputs haven&apos;t changed.
+      </div>
+    </div>
+  );
+}

--- a/ide/src/components/ide/MobileGatekeeper.tsx
+++ b/ide/src/components/ide/MobileGatekeeper.tsx
@@ -1,105 +1,121 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { AlertCircle, X } from "lucide-react";
+/**
+ * MobileGatekeeper.tsx
+ * Responsive mobile layout for read-only code review — Issue #815
+ *
+ * On mobile: renders a read-only banner + bottom nav instead of blocking the IDE.
+ * On desktop: renders nothing (IDE renders normally).
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  EyeOff,
+  FolderTree,
+  History,
+  Activity,
+  X,
+  Menu,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useWorkspaceStore, type MobilePanel } from "@/store/workspaceStore";
+
+const BOTTOM_NAV_ITEMS: {
+  id: MobilePanel;
+  icon: React.ReactNode;
+  label: string;
+}[] = [
+  { id: "explorer", icon: <FolderTree className="w-5 h-5" />, label: "Files" },
+  { id: "deployments", icon: <History className="w-5 h-5" />, label: "Deploy" },
+  { id: "identities", icon: <Activity className="w-5 h-5" />, label: "Status" },
+];
 
 export function MobileGatekeeper() {
   const [isMobile, setIsMobile] = useState(false);
-  const [isDismissed, setIsDismissed] = useState(false);
   const [isHydrated, setIsHydrated] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { mobilePanel, setMobilePanel } = useWorkspaceStore();
 
   useEffect(() => {
-    // Hydration: Run only on client
     setIsHydrated(true);
-
-    // Check localStorage for dismissal state
-    try {
-      const dismissed = localStorage.getItem("mobile-warning-dismissed");
-      setIsDismissed(dismissed === "true");
-    } catch (error) {
-      // localStorage might not be available
-      console.debug("localStorage not available:", error);
-    }
-
-    // Media query for mobile viewport
-    const mediaQuery = window.matchMedia("(max-width: 768px)");
-
-    const handleChange = (e: MediaQueryListEvent) => {
-      setIsMobile(e.matches);
-    };
-
-    // Initial check
-    setIsMobile(mediaQuery.matches);
-
-    // Add listener for viewport changes
-    mediaQuery.addEventListener("change", handleChange);
-
-    return () => {
-      mediaQuery.removeEventListener("change", handleChange);
-    };
+    const mq = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
   }, []);
 
-  const handleDismiss = () => {
-    try {
-      localStorage.setItem("mobile-warning-dismissed", "true");
-    } catch (error) {
-      console.debug("localStorage not available:", error);
-    }
-    setIsDismissed(true);
-  };
+  const handleNavClick = useCallback(
+    (panel: MobilePanel) => {
+      if (mobilePanel === panel) {
+        setMobilePanel("none");
+        setSidebarOpen(false);
+      } else {
+        setMobilePanel(panel);
+        setSidebarOpen(true);
+      }
+    },
+    [mobilePanel, setMobilePanel]
+  );
 
-  // Don't show until hydrated to avoid hydration mismatch
-  if (!isHydrated || !isMobile || isDismissed) {
-    return null;
-  }
+  const closeSidebar = useCallback(() => {
+    setSidebarOpen(false);
+    setMobilePanel("none");
+  }, [setMobilePanel]);
+
+  if (!isHydrated || !isMobile) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
-      {/* Modal */}
-      <div className="bg-card border border-border rounded-lg shadow-2xl max-w-md w-full p-8">
-        {/* Close button */}
-        <div className="flex justify-end mb-4">
-          <button
-            onClick={handleDismiss}
-            className="p-2 hover:bg-secondary rounded-md transition-colors"
-            aria-label="Close warning"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        {/* Icon */}
-        <div className="flex justify-center mb-6">
-          <AlertCircle className="w-12 h-12 text-warning" />
-        </div>
-
-        {/* Content */}
-        <div className="text-center space-y-4">
-          <h2 className="text-2xl font-bold text-foreground">
-            Desktop Recommended
-          </h2>
-
-          <p className="text-muted-foreground text-sm leading-relaxed">
-            Stellar Kit Canvas is best experienced on a Desktop environment.
-            Please switch devices to continue.
-          </p>
-        </div>
-
-        {/* Actions */}
-        <div className="mt-8 space-y-3">
-          <Button
-            onClick={handleDismiss}
-            className="w-full"
-            variant="default"
-          >
-            Continue Anyway
-          </Button>
-          <p className="text-xs text-muted-foreground text-center">
-            You can dismiss this warning at any time
-          </p>
-        </div>
+    <>
+      {/* Read-only banner */}
+      <div
+        className="ide-mobile-readonly-banner"
+        role="status"
+        aria-live="polite"
+      >
+        <EyeOff className="w-3 h-3 shrink-0" aria-hidden="true" />
+        <span>Read-only mode — editing disabled on mobile</span>
       </div>
-    </div>
+
+      {/* Sidebar backdrop */}
+      <div
+        className={`ide-sidebar-backdrop ${sidebarOpen ? "backdrop-visible" : ""}`}
+        aria-hidden="true"
+        onClick={closeSidebar}
+      />
+
+      {/* Bottom navigation */}
+      <nav
+        className="ide-bottom-nav"
+        aria-label="Mobile navigation"
+      >
+        <button
+          className="ide-bottom-nav-item"
+          onClick={() => setSidebarOpen((v) => !v)}
+          aria-label="Toggle menu"
+          aria-expanded={sidebarOpen}
+        >
+          {sidebarOpen ? (
+            <X className="w-5 h-5" aria-hidden="true" />
+          ) : (
+            <Menu className="w-5 h-5" aria-hidden="true" />
+          )}
+          <span>Menu</span>
+        </button>
+
+        {BOTTOM_NAV_ITEMS.map((item) => (
+          <button
+            key={item.id}
+            className={`ide-bottom-nav-item ${mobilePanel === item.id ? "active" : ""}`}
+            onClick={() => handleNavClick(item.id)}
+            aria-label={item.label}
+            aria-pressed={mobilePanel === item.id}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </button>
+        ))}
+      </nav>
+    </>
   );
 }

--- a/ide/src/components/ide/SponsorshipDelegationPanel.tsx
+++ b/ide/src/components/ide/SponsorshipDelegationPanel.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+/**
+ * SponsorshipDelegationPanel.tsx
+ * UI for delegating sponsorship rights to sub-accounts — Issue #837
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Shield,
+  Plus,
+  Trash2,
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  RefreshCw,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import {
+  DelegationStore,
+  type DelegationEntry,
+  type DelegationAuditEntry,
+} from "@/lib/identity/DelegationStore";
+
+const store = DelegationStore.getInstance();
+
+// ─── Delegation row ───────────────────────────────────────────────────────────
+
+function DelegationRow({
+  delegation,
+  onRevoke,
+}: {
+  delegation: DelegationEntry;
+  onRevoke: (delegate: string, sponsor: string) => void;
+}) {
+  const isExpired =
+    delegation.expiresAt ? delegation.expiresAt <= new Date().toISOString() : false;
+  const isActive = delegation.active && !isExpired;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-3 py-2.5 space-y-1.5 transition-all",
+        isActive
+          ? "border-border bg-card/50"
+          : "border-border/40 bg-muted/20 opacity-60"
+      )}
+      data-testid={`delegation-${delegation.delegatePublicKey.slice(0, 8)}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0 space-y-0.5">
+          <div className="flex items-center gap-1.5">
+            {isActive ? (
+              <CheckCircle2 className="h-3 w-3 text-emerald-400 shrink-0" />
+            ) : isExpired ? (
+              <Clock className="h-3 w-3 text-yellow-400 shrink-0" />
+            ) : (
+              <AlertCircle className="h-3 w-3 text-muted-foreground shrink-0" />
+            )}
+            <span className="text-[11px] font-semibold text-foreground truncate">
+              {delegation.label}
+            </span>
+          </div>
+          <div className="space-y-0.5">
+            <p className="text-[9px] text-muted-foreground">
+              <span className="uppercase tracking-wider">Delegate</span>{" "}
+              <span className="font-mono">
+                {delegation.delegatePublicKey.slice(0, 8)}…{delegation.delegatePublicKey.slice(-6)}
+              </span>
+            </p>
+            <p className="text-[9px] text-muted-foreground">
+              <span className="uppercase tracking-wider">Sponsor</span>{" "}
+              <span className="font-mono">
+                {delegation.sponsorPublicKey.slice(0, 8)}…{delegation.sponsorPublicKey.slice(-6)}
+              </span>
+            </p>
+            {delegation.expiresAt && (
+              <p className={cn("text-[9px]", isExpired ? "text-yellow-400" : "text-muted-foreground")}>
+                {isExpired ? "Expired" : "Expires"}{" "}
+                {new Date(delegation.expiresAt).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+        </div>
+        {isActive && (
+          <button
+            onClick={() => onRevoke(delegation.delegatePublicKey, delegation.sponsorPublicKey)}
+            className="shrink-0 text-muted-foreground hover:text-destructive transition-colors mt-0.5"
+            aria-label={`Revoke delegation for ${delegation.label}`}
+            data-testid={`revoke-${delegation.delegatePublicKey.slice(0, 8)}`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Add delegation form ──────────────────────────────────────────────────────
+
+function AddDelegationForm({ onAdd }: { onAdd: () => void }) {
+  const [delegateKey, setDelegateKey] = useState("");
+  const [sponsorKey, setSponsorKey] = useState("");
+  const [label, setLabel] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setError(null);
+    if (!delegateKey.trim() || !delegateKey.startsWith("G")) {
+      setError("Delegate must be a valid Stellar public key (starts with G).");
+      return;
+    }
+    if (!sponsorKey.trim() || !sponsorKey.startsWith("G")) {
+      setError("Sponsor must be a valid Stellar public key (starts with G).");
+      return;
+    }
+    if (delegateKey === sponsorKey) {
+      setError("Delegate and sponsor cannot be the same account.");
+      return;
+    }
+    if (!label.trim()) {
+      setError("Label is required.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await store.addDelegation({
+        delegatePublicKey: delegateKey.trim(),
+        sponsorPublicKey: sponsorKey.trim(),
+        label: label.trim(),
+        expiresAt: expiresAt || undefined,
+      });
+      toast.success(`Delegation created for ${label.trim()}`);
+      setDelegateKey("");
+      setSponsorKey("");
+      setLabel("");
+      setExpiresAt("");
+      onAdd();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border bg-card/30 p-3">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        New Delegation
+      </p>
+
+      <div className="space-y-1.5">
+        <div>
+          <label className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Label
+          </label>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="e.g. CI Bot Account"
+            className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            data-testid="delegation-label"
+          />
+        </div>
+        <div>
+          <label className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Delegate Public Key
+          </label>
+          <input
+            value={delegateKey}
+            onChange={(e) => setDelegateKey(e.target.value)}
+            placeholder="G... (sub-account)"
+            className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            data-testid="delegation-delegate-key"
+          />
+        </div>
+        <div>
+          <label className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Sponsor Public Key
+          </label>
+          <input
+            value={sponsorKey}
+            onChange={(e) => setSponsorKey(e.target.value)}
+            placeholder="G... (fee payer)"
+            className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            data-testid="delegation-sponsor-key"
+          />
+        </div>
+        <div>
+          <label className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Expires (optional)
+          </label>
+          <input
+            type="date"
+            value={expiresAt}
+            onChange={(e) =>
+              setExpiresAt(
+                e.target.value ? new Date(e.target.value).toISOString() : ""
+              )
+            }
+            className="mt-0.5 w-full rounded border border-border bg-background px-2 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+            data-testid="delegation-expires"
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-1.5 text-[10px] text-destructive">
+          <AlertCircle className="h-3 w-3 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={handleSubmit}
+        disabled={isSubmitting}
+        className="w-full flex items-center justify-center gap-1.5 rounded bg-primary/15 py-1.5 text-[10px] font-bold text-primary hover:bg-primary/25 transition-colors disabled:opacity-50"
+        data-testid="add-delegation-submit"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {isSubmitting ? "Creating…" : "Create Delegation"}
+      </button>
+    </div>
+  );
+}
+
+// ─── Audit log ────────────────────────────────────────────────────────────────
+
+function AuditLog({ entries }: { entries: DelegationAuditEntry[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="space-y-1">
+      <button
+        className="flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        Audit Log ({entries.length})
+      </button>
+      {expanded && (
+        <div className="space-y-1 max-h-40 overflow-y-auto">
+          {entries.slice(0, 50).map((entry) => (
+            <div
+              key={entry.id}
+              className="flex items-start gap-2 text-[9px] font-mono text-muted-foreground"
+            >
+              <span
+                className={cn(
+                  "shrink-0 uppercase",
+                  entry.action === "sponsored"
+                    ? "text-emerald-400"
+                    : entry.action === "revoked"
+                    ? "text-destructive"
+                    : "text-yellow-400"
+                )}
+              >
+                {entry.action}
+              </span>
+              <span className="truncate">
+                {entry.delegatePublicKey.slice(0, 8)}…
+              </span>
+              <span className="shrink-0 text-muted-foreground/60">
+                {new Date(entry.timestamp).toLocaleTimeString()}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main panel ───────────────────────────────────────────────────────────────
+
+export function SponsorshipDelegationPanel() {
+  const [delegations, setDelegations] = useState<DelegationEntry[]>([]);
+  const [auditLog, setAuditLog] = useState<DelegationAuditEntry[]>([]);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    await store.load();
+    await store.pruneExpired();
+    setDelegations(store.getDelegations());
+    setAuditLog(store.getAuditLog());
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleRevoke = async (delegate: string, sponsor: string) => {
+    try {
+      await store.revokeDelegation(delegate, sponsor);
+      toast.success("Delegation revoked");
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const activeDelegations = delegations.filter(
+    (d) => d.active && (!d.expiresAt || d.expiresAt > new Date().toISOString())
+  );
+  const inactiveDelegations = delegations.filter(
+    (d) => !d.active || (d.expiresAt && d.expiresAt <= new Date().toISOString())
+  );
+
+  return (
+    <div
+      className="flex h-full flex-col bg-sidebar overflow-hidden"
+      data-testid="sponsorship-delegation-panel"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-sidebar-border px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <Shield className="h-3.5 w-3.5 text-primary" />
+          <span className="text-xs font-semibold text-foreground">
+            Sponsorship Delegation
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-muted-foreground">
+            {activeDelegations.length} active
+          </span>
+          <button
+            onClick={refresh}
+            className="ml-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Refresh delegations"
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "animate-spin")} />
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2">
+        {/* Active delegations */}
+        {activeDelegations.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Active
+            </p>
+            {activeDelegations.map((d) => (
+              <DelegationRow
+                key={`${d.delegatePublicKey}:${d.sponsorPublicKey}`}
+                delegation={d}
+                onRevoke={handleRevoke}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Inactive / expired */}
+        {inactiveDelegations.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Inactive / Expired
+            </p>
+            {inactiveDelegations.map((d) => (
+              <DelegationRow
+                key={`${d.delegatePublicKey}:${d.sponsorPublicKey}`}
+                delegation={d}
+                onRevoke={handleRevoke}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Add form */}
+        {showAddForm ? (
+          <AddDelegationForm
+            onAdd={async () => {
+              setShowAddForm(false);
+              await refresh();
+            }}
+          />
+        ) : (
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="w-full flex items-center justify-center gap-1.5 rounded border border-dashed border-border py-2 text-[10px] text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+            data-testid="show-add-delegation-form"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add Delegation
+          </button>
+        )}
+
+        {/* Empty state */}
+        {delegations.length === 0 && !showAddForm && !isLoading && (
+          <p className="text-[10px] text-muted-foreground italic text-center py-4">
+            No delegations configured. Add one to allow sub-accounts to use a sponsor.
+          </p>
+        )}
+
+        {/* Audit log */}
+        <AuditLog entries={auditLog} />
+      </div>
+
+      <div className="border-t border-sidebar-border px-3 py-2 text-[9px] text-muted-foreground leading-relaxed">
+        Delegations allow sub-accounts to have their transaction fees covered by a sponsor account.
+      </div>
+    </div>
+  );
+}

--- a/ide/src/components/layout/ActivityBar.tsx
+++ b/ide/src/components/layout/ActivityBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FolderTree,
   Users,
@@ -8,9 +10,11 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   Settings,
+  Globe,
 } from "lucide-react";
-import { ReactNode } from "react";
+import { ReactNode, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { useSidebarOrderStore } from "@/store/useSidebarOrderStore";
 
 export type ActivityTab =
   | "explorer"
@@ -36,7 +40,7 @@ interface ActivityBarTab {
   title: string;
 }
 
-const tabs: ActivityBarTab[] = [
+const TAB_DEFINITIONS: ActivityBarTab[] = [
   {
     id: "explorer",
     icon: <FolderTree className="h-5 w-5" />,
@@ -87,32 +91,82 @@ const tabs: ActivityBarTab[] = [
   },
 ];
 
+const TAB_MAP = Object.fromEntries(
+  TAB_DEFINITIONS.map((t) => [t.id, t])
+) as Record<ActivityTab, ActivityBarTab>;
+
 export function ActivityBar({
   activeTab,
   onTabChange,
   sidebarVisible,
   onToggleSidebar,
 }: ActivityBarProps) {
+  const { order, moveTab } = useSidebarOrderStore();
+  const dragIndex = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const orderedTabs = order
+    .map((id) => TAB_MAP[id])
+    .filter(Boolean) as ActivityBarTab[];
+
+  const handleDragStart = (index: number) => {
+    dragIndex.current = index;
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    setDragOverIndex(index);
+  };
+
+  const handleDrop = (toIndex: number) => {
+    if (dragIndex.current !== null && dragIndex.current !== toIndex) {
+      moveTab(dragIndex.current, toIndex);
+    }
+    dragIndex.current = null;
+    setDragOverIndex(null);
+  };
+
+  const handleDragEnd = () => {
+    dragIndex.current = null;
+    setDragOverIndex(null);
+  };
+
   return (
-    <div className="hidden md:flex flex-col bg-sidebar border-r border-border shrink-0 w-12 items-center py-4 gap-4">
+    <div
+      className="hidden md:flex flex-col bg-sidebar border-r border-border shrink-0 w-12 items-center py-4 gap-4 ide-activity-bar"
+      role="navigation"
+      aria-label="Activity bar"
+    >
       <div className="flex flex-col gap-2">
-        {tabs.map((tab) => (
-          <Button
+        {orderedTabs.map((tab, index) => (
+          <div
             key={tab.id}
-            variant={activeTab === tab.id ? "secondary" : "ghost"}
-            size="icon"
-            onClick={() => onTabChange(tab.id)}
-            className={`h-9 w-9 ${
-              activeTab === tab.id
-                ? "bg-primary/20 text-primary hover:bg-primary/30"
-                : "text-muted-foreground hover:text-foreground"
+            draggable
+            onDragStart={() => handleDragStart(index)}
+            onDragOver={(e) => handleDragOver(e, index)}
+            onDrop={() => handleDrop(index)}
+            onDragEnd={handleDragEnd}
+            className={`rounded transition-all ${
+              dragOverIndex === index ? "ring-1 ring-primary/60 scale-105" : ""
             }`}
-            title={tab.title}
-            aria-label={tab.label}
-            aria-pressed={activeTab === tab.id}
+            title="Drag to reorder"
           >
-            {tab.icon}
-          </Button>
+            <Button
+              variant={activeTab === tab.id ? "secondary" : "ghost"}
+              size="icon"
+              onClick={() => onTabChange(tab.id)}
+              className={`h-9 w-9 cursor-grab active:cursor-grabbing ${
+                activeTab === tab.id
+                  ? "bg-primary/20 text-primary hover:bg-primary/30"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              title={tab.title}
+              aria-label={tab.label}
+              aria-pressed={activeTab === tab.id}
+            >
+              {tab.icon}
+            </Button>
+          </div>
         ))}
       </div>
 

--- a/ide/src/lib/testing/invocationSnapshotVerifier.ts
+++ b/ide/src/lib/testing/invocationSnapshotVerifier.ts
@@ -1,0 +1,176 @@
+/**
+ * invocationSnapshotVerifier.ts
+ * Record-and-replay snapshot verification for contract invocations — Issue #840
+ *
+ * Bridges the InteractionRecorder (recorded sessions) with the SnapshotManager
+ * (expected outputs) to provide automated regression testing for contract calls.
+ */
+
+import { snapshotManager, type SnapshotDiff } from "./snapshotManager";
+import { interactionRecorder, type RecordingSession, type RecordedInteraction } from "./interactionRecorder";
+
+export interface InvocationSnapshot {
+  /** Unique key: "<sessionId>::<interactionId>" */
+  key: string;
+  sessionId: string;
+  interactionId: string;
+  contractId: string;
+  functionName: string;
+  args: string;
+  /** The recorded result that serves as the expected baseline */
+  expectedResult: RecordedInteraction["result"];
+  createdAt: string;
+}
+
+export interface VerificationResult {
+  interactionId: string;
+  functionName: string;
+  contractId: string;
+  args: string;
+  passed: boolean;
+  /** Present when the replay result differs from the snapshot */
+  diffs?: SnapshotDiff[];
+  /** The actual result from the replay */
+  actualResult?: RecordedInteraction["result"];
+  /** The expected result from the snapshot */
+  expectedResult?: RecordedInteraction["result"];
+  error?: string;
+}
+
+export interface SessionVerificationReport {
+  sessionId: string;
+  sessionName: string;
+  totalInteractions: number;
+  passed: number;
+  failed: number;
+  errors: number;
+  results: VerificationResult[];
+  ranAt: string;
+}
+
+const SNAPSHOT_PATH_PREFIX = "invocation-snapshots";
+
+function makeSnapshotPath(sessionId: string): string {
+  return `${SNAPSHOT_PATH_PREFIX}/${sessionId}`;
+}
+
+function makeSnapshotName(interaction: RecordedInteraction): string {
+  return `${interaction.functionName}(${interaction.args})@${interaction.contractId.slice(0, 8)}`;
+}
+
+/**
+ * Record a session's interactions as snapshot baselines.
+ * Call this after a successful "golden run" to establish expected outputs.
+ */
+export async function recordSessionSnapshots(session: RecordingSession): Promise<number> {
+  let saved = 0;
+  for (const interaction of session.interactions) {
+    if (!interaction.result) continue;
+    const testPath = makeSnapshotPath(session.id);
+    const testName = makeSnapshotName(interaction);
+    await snapshotManager.saveSnapshot(testPath, testName, interaction.result);
+    saved++;
+  }
+  return saved;
+}
+
+/**
+ * Verify a replay session against previously recorded snapshots.
+ * Returns a full report with per-interaction pass/fail results.
+ */
+export async function verifySessionAgainstSnapshots(
+  replaySession: RecordingSession,
+  baselineSessionId: string
+): Promise<SessionVerificationReport> {
+  const results: VerificationResult[] = [];
+  const testPath = makeSnapshotPath(baselineSessionId);
+
+  for (const interaction of replaySession.interactions) {
+    const testName = makeSnapshotName(interaction);
+    const base: VerificationResult = {
+      interactionId: interaction.id,
+      functionName: interaction.functionName,
+      contractId: interaction.contractId,
+      args: interaction.args,
+      passed: false,
+      actualResult: interaction.result,
+    };
+
+    try {
+      const snapshot = await snapshotManager.getSnapshot(testPath, testName);
+      if (!snapshot) {
+        results.push({
+          ...base,
+          error: `No baseline snapshot found for "${testName}". Run a golden session first.`,
+        });
+        continue;
+      }
+
+      base.expectedResult = snapshot.data as RecordedInteraction["result"];
+      const match = await snapshotManager.matchSnapshot(testPath, testName, interaction.result);
+
+      results.push({
+        ...base,
+        passed: match.matches,
+        diffs: match.diffs,
+      });
+    } catch (err) {
+      results.push({
+        ...base,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.filter((r) => !r.passed && !r.error).length;
+  const errors = results.filter((r) => !!r.error).length;
+
+  return {
+    sessionId: replaySession.id,
+    sessionName: replaySession.name,
+    totalInteractions: replaySession.interactions.length,
+    passed,
+    failed,
+    errors,
+    results,
+    ranAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * List all sessions that have snapshot baselines recorded.
+ */
+export async function getSessionsWithSnapshots(): Promise<string[]> {
+  const allSnapshots = await snapshotManager.getAllSnapshots();
+  const sessionIds = new Set<string>();
+  for (const snap of allSnapshots) {
+    if (snap.metadata.testPath.startsWith(SNAPSHOT_PATH_PREFIX + "/")) {
+      const sessionId = snap.metadata.testPath.slice(SNAPSHOT_PATH_PREFIX.length + 1);
+      sessionIds.add(sessionId);
+    }
+  }
+  return [...sessionIds];
+}
+
+/**
+ * Delete all snapshots for a given session baseline.
+ */
+export async function clearSessionSnapshots(sessionId: string): Promise<void> {
+  const testPath = makeSnapshotPath(sessionId);
+  const allSnapshots = await snapshotManager.getAllSnapshots();
+  for (const snap of allSnapshots) {
+    if (snap.metadata.testPath === testPath) {
+      await snapshotManager.deleteSnapshot(testPath, snap.metadata.testName);
+    }
+  }
+}
+
+/**
+ * Convenience: record the current active session as a baseline.
+ */
+export async function recordCurrentSessionAsBaseline(): Promise<number> {
+  const session = interactionRecorder.getCurrentSession();
+  if (!session) throw new Error("No active recording session");
+  return recordSessionSnapshots(session);
+}

--- a/ide/src/store/useSidebarOrderStore.ts
+++ b/ide/src/store/useSidebarOrderStore.ts
@@ -1,0 +1,54 @@
+/**
+ * useSidebarOrderStore.ts
+ * Persisted store for customizable sidebar icon order — Issue #816
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { ActivityTab } from "@/components/layout/ActivityBar";
+
+const DEFAULT_ORDER: ActivityTab[] = [
+  "explorer",
+  "git",
+  "search",
+  "deployments",
+  "identities",
+  "security",
+  "tests",
+  "network",
+];
+
+interface SidebarOrderState {
+  order: ActivityTab[];
+  setOrder: (order: ActivityTab[]) => void;
+  moveTab: (fromIndex: number, toIndex: number) => void;
+  resetOrder: () => void;
+}
+
+export const useSidebarOrderStore = create<SidebarOrderState>()(
+  persist(
+    (set) => ({
+      order: DEFAULT_ORDER,
+
+      setOrder: (order) => set({ order }),
+
+      moveTab: (fromIndex, toIndex) =>
+        set((state) => {
+          const next = [...state.order];
+          const [moved] = next.splice(fromIndex, 1);
+          next.splice(toIndex, 0, moved);
+          return { order: next };
+        }),
+
+      resetOrder: () => set({ order: DEFAULT_ORDER }),
+    }),
+    {
+      name: "stellar-suite:sidebar-order",
+      storage: createJSONStorage(() =>
+        typeof window !== "undefined"
+          ? window.localStorage
+          : { getItem: () => null, setItem: () => {}, removeItem: () => {} }
+      ),
+    }
+  )
+);


### PR DESCRIPTION
#815 - Responsive Mobile Layout (Read-Only)
- Rework MobileGatekeeper into a proper mobile read-only layout
- Adds read-only banner, bottom navigation bar, and sidebar drawer support
- Leverages existing mobile-responsive.css classes (ide-bottom-nav, ide-mobile-readonly-banner, ide-sidebar-backdrop)
- Disables editing actions on mobile; exposes Files/Deploy/Status nav items

#816 - Customizable Sidebar and Tab Draggability
- Add useSidebarOrderStore (persisted to localStorage) for sidebar icon order
- ActivityBar now supports HTML5 drag-and-drop to reorder sidebar icons
- EditorTabs now supports drag-and-drop to reorder open tabs
- Tab order is reflected immediately in the workspace store

#837 - Sponsorship Delegation for Sub-accounts
- Add SponsorshipDelegationPanel component backed by existing DelegationStore
- UI to create, view, and revoke sponsorship delegations for sub-accounts
- Supports optional expiry dates and auto-prunes expired delegations on load
- Collapsible audit log showing sponsored/revoked/expired events

#840 - Automated Snapshot Verification for Invocations
- Add invocationSnapshotVerifier.ts bridging InteractionRecorder + SnapshotManager
- recordSessionSnapshots(): saves a golden session as snapshot baselines
- verifySessionAgainstSnapshots(): replays a session and diffs against baselines
- Add InvocationSnapshotPanel component for record-and-replay UI in the IDE

Closes #815
Closes #816
Closes #837
Closes #840