### PR TITLE
refactor: abstract-filesystem-interface

### DIFF
--- a/ide/src/lib/fs/FileSystemProvider.ts
+++ b/ide/src/lib/fs/FileSystemProvider.ts
@@ -1,0 +1,108 @@
+/**
+ * Issue #882 — Abstract File System Operations to an Adaptable Interface.
+ *
+ * The IDE historically reached for browser storage APIs (localStorage /
+ * IndexedDB) directly from feature code, coupling the workspace to a single
+ * persistence backend. This module defines a single `FileSystemProvider`
+ * interface that all storage targets implement, so core operations compile
+ * against the abstraction rather than a concrete backend.
+ *
+ * Adapters (see ./adapters):
+ *  - BrowserFileSystemProvider  — IndexedDB-backed, for in-browser workspaces.
+ *  - LocalFileSystemProvider    — Node `fs` rooted at a directory (desktop/server).
+ *  - GitHubFileSystemProvider   — remote GitHub repository via the REST API.
+ *
+ * All paths are POSIX-style, forward-slash separated, and normalised relative
+ * to the provider root. A leading slash is optional and treated the same as
+ * none ("/a/b.rs" === "a/b.rs").
+ */
+
+/** Metadata describing a single entry returned by `list`/`stat`. */
+export interface FileStat {
+  /** Normalised POSIX path of the entry, relative to the provider root. */
+  path: string;
+  /** Whether the entry is a directory. */
+  isDirectory: boolean;
+  /** Size in bytes (0 for directories or when the backend cannot report it). */
+  size: number;
+  /** Last-modified time in epoch milliseconds, when the backend tracks it. */
+  mtime?: number;
+}
+
+/** Error thrown when an operation targets a path that does not exist. */
+export class FileNotFoundError extends Error {
+  constructor(path: string) {
+    super(`File not found: ${path}`);
+    this.name = "FileNotFoundError";
+  }
+}
+
+/**
+ * Unified file-system abstraction. Every storage backend implements this so
+ * the editor, explorer, and tooling can be written against one contract.
+ */
+export interface FileSystemProvider {
+  /** Stable identifier of the backend, e.g. "browser" | "local" | "github". */
+  readonly id: string;
+
+  /** Read a UTF-8 text file. Throws `FileNotFoundError` if absent. */
+  readFile(path: string): Promise<string>;
+
+  /** Create or overwrite a UTF-8 text file, creating parent dirs as needed. */
+  writeFile(path: string, content: string): Promise<void>;
+
+  /** Delete a file (or empty directory). No-op if the path does not exist. */
+  delete(path: string): Promise<void>;
+
+  /** Whether a file or directory exists at `path`. */
+  exists(path: string): Promise<boolean>;
+
+  /**
+   * List immediate children of a directory. Returns `[]` for an empty or
+   * missing directory. Pass "" (root) to list the top level.
+   */
+  list(dir: string): Promise<FileStat[]>;
+
+  /** Stat a single entry. Throws `FileNotFoundError` if absent. */
+  stat(path: string): Promise<FileStat>;
+}
+
+/**
+ * Normalise a path to the provider-internal canonical form:
+ *  - backslashes → forward slashes
+ *  - collapse duplicate slashes
+ *  - resolve "." and ".." segments
+ *  - strip leading/trailing slashes
+ *
+ * Throws if the path escapes the root via "..".
+ */
+export function normalizePath(input: string): string {
+  const raw = input.replace(/\\/g, "/");
+  const out: string[] = [];
+  for (const segment of raw.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      if (out.length === 0) {
+        throw new Error(`Path escapes root: ${input}`);
+      }
+      out.pop();
+      continue;
+    }
+    out.push(segment);
+  }
+  return out.join("/");
+}
+
+/** Return the parent directory of a normalised path ("" for top-level). */
+export function dirname(path: string): string {
+  const normalized = normalizePath(path);
+  const idx = normalized.lastIndexOf("/");
+  return idx === -1 ? "" : normalized.slice(0, idx);
+}
+
+/** Return the final path segment (file or directory name). */
+export function basename(path: string): string {
+  const normalized = normalizePath(path);
+  const idx = normalized.lastIndexOf("/");
+  return idx === -1 ? normalized : normalized.slice(idx + 1);
+}

--- a/ide/src/lib/fs/__tests__/FileSystemProvider.test.ts
+++ b/ide/src/lib/fs/__tests__/FileSystemProvider.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FileNotFoundError,
+  basename,
+  dirname,
+  normalizePath,
+} from "@/lib/fs/FileSystemProvider";
+import { BrowserFileSystemProvider } from "@/lib/fs/adapters/BrowserFileSystemProvider";
+import { LocalFileSystemProvider } from "@/lib/fs/adapters/LocalFileSystemProvider";
+import { GitHubFileSystemProvider } from "@/lib/fs/adapters/GitHubFileSystemProvider";
+
+// ── Path helpers ─────────────────────────────────────────────────────────────
+
+describe("path helpers", () => {
+  it("normalizes slashes, dot segments, and leading/trailing slashes", () => {
+    expect(normalizePath("/a/b/c.rs")).toBe("a/b/c.rs");
+    expect(normalizePath("a\\b\\c.rs")).toBe("a/b/c.rs");
+    expect(normalizePath("a//b/./c.rs")).toBe("a/b/c.rs");
+    expect(normalizePath("a/b/../c.rs")).toBe("a/c.rs");
+    expect(normalizePath("")).toBe("");
+  });
+
+  it("throws when a path escapes the root", () => {
+    expect(() => normalizePath("../escape")).toThrow(/escapes root/);
+    expect(() => normalizePath("a/../../escape")).toThrow(/escapes root/);
+  });
+
+  it("derives dirname and basename", () => {
+    expect(dirname("a/b/c.rs")).toBe("a/b");
+    expect(dirname("top.rs")).toBe("");
+    expect(basename("a/b/c.rs")).toBe("c.rs");
+    expect(basename("top.rs")).toBe("top.rs");
+  });
+});
+
+// ── Browser (IndexedDB) adapter — uses fake-indexeddb from test setup ────────
+
+describe("BrowserFileSystemProvider", () => {
+  let fs: BrowserFileSystemProvider;
+
+  beforeEach(() => {
+    // Unique DB per test for isolation.
+    fs = new BrowserFileSystemProvider(`test-fs-${Math.random().toString(36).slice(2)}`);
+  });
+
+  it("exposes a stable id", () => {
+    expect(fs.id).toBe("browser");
+  });
+
+  it("writes and reads a file", async () => {
+    await fs.writeFile("src/lib.rs", "pub fn x() {}");
+    expect(await fs.readFile("src/lib.rs")).toBe("pub fn x() {}");
+  });
+
+  it("normalizes paths so equivalent forms hit the same entry", async () => {
+    await fs.writeFile("/src/lib.rs", "v1");
+    expect(await fs.readFile("src/lib.rs")).toBe("v1");
+  });
+
+  it("throws FileNotFoundError for a missing file", async () => {
+    await expect(fs.readFile("nope.rs")).rejects.toBeInstanceOf(FileNotFoundError);
+  });
+
+  it("reports existence for files and implicit directories", async () => {
+    await fs.writeFile("a/b/c.rs", "x");
+    expect(await fs.exists("a/b/c.rs")).toBe(true);
+    expect(await fs.exists("a/b")).toBe(true); // implicit dir
+    expect(await fs.exists("a")).toBe(true);
+    expect(await fs.exists("z")).toBe(false);
+  });
+
+  it("lists immediate children (files + subdirectories)", async () => {
+    await fs.writeFile("root.rs", "x");
+    await fs.writeFile("sub/a.rs", "x");
+    await fs.writeFile("sub/deep/b.rs", "x");
+
+    const top = await fs.list("");
+    expect(top.find((e) => e.path === "root.rs")?.isDirectory).toBe(false);
+    expect(top.find((e) => e.path === "sub")?.isDirectory).toBe(true);
+
+    const sub = await fs.list("sub");
+    expect(sub.map((e) => e.path).sort()).toEqual(["sub/a.rs", "sub/deep"]);
+  });
+
+  it("stats files and directories, and deletes files", async () => {
+    await fs.writeFile("dir/file.rs", "hello");
+    const fileStat = await fs.stat("dir/file.rs");
+    expect(fileStat.isDirectory).toBe(false);
+    expect(fileStat.size).toBe(5);
+
+    const dirStat = await fs.stat("dir");
+    expect(dirStat.isDirectory).toBe(true);
+
+    await fs.delete("dir/file.rs");
+    expect(await fs.exists("dir/file.rs")).toBe(false);
+  });
+});
+
+// ── Local (Node fs) adapter — injected in-memory fs mock ─────────────────────
+
+/**
+ * Minimal in-memory stand-in for node:fs/promises used by the local adapter.
+ * Keys are normalised to forward slashes so the mock behaves identically on
+ * Windows (where path.join emits backslashes) and POSIX.
+ */
+function makeMemoryFs() {
+  const files = new Map<string, string>();
+  const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "");
+  const ENOENT = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  return {
+    store: files,
+    async readFile(p: string) {
+      const key = norm(p);
+      if (!files.has(key)) throw ENOENT();
+      return files.get(key)!;
+    },
+    async writeFile(p: string, content: string) {
+      files.set(norm(p), content);
+    },
+    async mkdir() {
+      /* no-op: flat map needs no directories */
+    },
+    async rm(p: string) {
+      const key = norm(p);
+      // Remove the file and anything beneath it (recursive).
+      for (const existing of [...files.keys()]) {
+        if (existing === key || existing.startsWith(key + "/")) {
+          files.delete(existing);
+        }
+      }
+    },
+    async stat(p: string) {
+      const key = norm(p);
+      const isDir = [...files.keys()].some((k) => k.startsWith(key + "/"));
+      if (!files.has(key) && !isDir) throw ENOENT();
+      const content = files.get(key);
+      return {
+        isDirectory: () => !files.has(key) && isDir,
+        size: content ? content.length : 0,
+        mtimeMs: 123,
+      };
+    },
+    async readdir(p: string) {
+      const prefix = norm(p) + "/";
+      const names = new Set<string>();
+      const dirs = new Set<string>();
+      for (const key of files.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const rest = key.slice(prefix.length);
+        const slash = rest.indexOf("/");
+        if (slash === -1) names.add(rest);
+        else dirs.add(rest.slice(0, slash));
+      }
+      return [
+        ...[...names].map((n) => ({ name: n, isDirectory: () => false })),
+        ...[...dirs].map((n) => ({ name: n, isDirectory: () => true })),
+      ];
+    },
+  };
+}
+
+describe("LocalFileSystemProvider", () => {
+  let mem: ReturnType<typeof makeMemoryFs>;
+  let fs: LocalFileSystemProvider;
+  const ROOT = "/workspace";
+
+  beforeEach(() => {
+    mem = makeMemoryFs();
+    fs = new LocalFileSystemProvider(ROOT, mem as never);
+  });
+
+  it("exposes a stable id", () => {
+    expect(fs.id).toBe("local");
+  });
+
+  it("writes and reads relative to the root", async () => {
+    await fs.writeFile("src/main.rs", "fn main() {}");
+    expect(await fs.readFile("src/main.rs")).toBe("fn main() {}");
+    // Stored under the resolved absolute path.
+    expect([...mem.store.keys()].some((k) => k.includes("main.rs"))).toBe(true);
+  });
+
+  it("throws FileNotFoundError for a missing file", async () => {
+    await expect(fs.readFile("ghost.rs")).rejects.toBeInstanceOf(FileNotFoundError);
+  });
+
+  it("reports existence and deletes", async () => {
+    await fs.writeFile("a.rs", "x");
+    expect(await fs.exists("a.rs")).toBe(true);
+    await fs.delete("a.rs");
+    expect(await fs.exists("a.rs")).toBe(false);
+  });
+
+  it("delete is a no-op for a missing path", async () => {
+    await expect(fs.delete("missing.rs")).resolves.toBeUndefined();
+  });
+
+  it("lists directory entries and returns [] for a missing directory", async () => {
+    await fs.writeFile("pkg/a.rs", "x");
+    await fs.writeFile("pkg/sub/b.rs", "x");
+    const entries = await fs.list("pkg");
+    expect(entries.map((e) => e.path).sort()).toEqual(["pkg/a.rs", "pkg/sub"]);
+    expect(await fs.list("does-not-exist")).toEqual([]);
+  });
+
+  it("refuses paths that escape the root", async () => {
+    await expect(fs.readFile("../../etc/passwd")).rejects.toThrow(/escapes root/);
+  });
+});
+
+// ── GitHub (remote) adapter — injected fetch mock ────────────────────────────
+
+describe("GitHubFileSystemProvider", () => {
+  const base = "https://api.test";
+  const opts = (fetchImpl: unknown) => ({
+    owner: "octo",
+    repo: "demo",
+    branch: "main",
+    token: "tok",
+    apiBase: base,
+    fetchImpl: fetchImpl as never,
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("exposes a stable id", () => {
+    const fs = new GitHubFileSystemProvider(opts(vi.fn()));
+    expect(fs.id).toBe("github");
+  });
+
+  it("reads and base64-decodes a file blob", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        type: "file",
+        name: "lib.rs",
+        path: "src/lib.rs",
+        size: 11,
+        sha: "abc",
+        encoding: "base64",
+        content: Buffer.from("pub fn y(){}").toString("base64"),
+      }),
+    });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    expect(await fs.readFile("src/lib.rs")).toBe("pub fn y(){}");
+    // Sends auth header and ref.
+    expect(fetchImpl).toHaveBeenCalledWith(
+      `${base}/repos/octo/demo/contents/src/lib.rs?ref=main`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+  });
+
+  it("throws FileNotFoundError on a 404", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    await expect(fs.readFile("nope.rs")).rejects.toBeInstanceOf(FileNotFoundError);
+  });
+
+  it("creates a new file with a PUT (no sha) when none exists", async () => {
+    const calls: Array<{ url: string; init?: { method?: string; body?: string } }> = [];
+    const fetchImpl = vi.fn().mockImplementation((url: string, init?: { method?: string; body?: string }) => {
+      calls.push({ url, init });
+      if (init?.method === "PUT") {
+        return Promise.resolve({ ok: true, status: 201, json: async () => ({}) });
+      }
+      // initial existence GET → 404
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+    });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    await fs.writeFile("new.rs", "content");
+
+    const put = calls.find((c) => c.init?.method === "PUT")!;
+    expect(put).toBeDefined();
+    const body = JSON.parse(put.init!.body!);
+    expect(body.sha).toBeUndefined(); // new file → no sha
+    expect(Buffer.from(body.content, "base64").toString("utf-8")).toBe("content");
+  });
+
+  it("updates an existing file by including its blob sha", async () => {
+    const fetchImpl = vi.fn().mockImplementation((url: string, init?: { method?: string }) => {
+      if (!init || init.method === undefined || init.method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ type: "file", name: "x", path: "x.rs", size: 1, sha: "OLD_SHA" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
+    });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    await fs.writeFile("x.rs", "updated");
+
+    const put = fetchImpl.mock.calls.find((c) => c[1]?.method === "PUT")!;
+    const body = JSON.parse(put[1].body);
+    expect(body.sha).toBe("OLD_SHA");
+  });
+
+  it("lists a directory's entries", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        { type: "file", name: "a.rs", path: "src/a.rs", size: 3, sha: "1" },
+        { type: "dir", name: "sub", path: "src/sub", size: 0, sha: "2" },
+      ],
+    });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    const entries = await fs.list("src");
+    expect(entries).toEqual([
+      { path: "src/a.rs", isDirectory: false, size: 3 },
+      { path: "src/sub", isDirectory: true, size: 0 },
+    ]);
+  });
+
+  it("reports existence via exists()", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ type: "file", path: "a", size: 1, sha: "s" }) })
+      .mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+    const fs = new GitHubFileSystemProvider(opts(fetchImpl));
+    expect(await fs.exists("a.rs")).toBe(true);
+    expect(await fs.exists("missing.rs")).toBe(false);
+  });
+});
+
+// ── Cross-adapter contract: all three satisfy the same interface shape ───────
+
+describe("FileSystemProvider contract", () => {
+  it("every adapter implements the full interface surface", () => {
+    const browser = new BrowserFileSystemProvider("contract-test");
+    const local = new LocalFileSystemProvider("/root", makeMemoryFs() as never);
+    const github = new GitHubFileSystemProvider({
+      owner: "o",
+      repo: "r",
+      fetchImpl: vi.fn() as never,
+    });
+    for (const provider of [browser, local, github]) {
+      expect(typeof provider.id).toBe("string");
+      for (const method of ["readFile", "writeFile", "delete", "exists", "list", "stat"] as const) {
+        expect(typeof provider[method]).toBe("function");
+      }
+    }
+  });
+});

--- a/ide/src/lib/fs/adapters/BrowserFileSystemProvider.ts
+++ b/ide/src/lib/fs/adapters/BrowserFileSystemProvider.ts
@@ -1,0 +1,170 @@
+/**
+ * Issue #882 — Browser (IndexedDB) adapter for {@link FileSystemProvider}.
+ *
+ * Stores each file as a record keyed by its normalised path in a single
+ * IndexedDB object store. Directories are implicit: they exist when at least
+ * one file is stored beneath them. This is the default backend for in-browser
+ * workspaces and replaces ad-hoc localStorage/IndexedDB access scattered across
+ * feature code.
+ */
+import {
+  FileNotFoundError,
+  type FileStat,
+  type FileSystemProvider,
+  basename,
+  normalizePath,
+} from "../FileSystemProvider";
+
+interface StoredFile {
+  path: string;
+  content: string;
+  size: number;
+  mtime: number;
+}
+
+const DEFAULT_DB = "stellar-suite-fs";
+const STORE = "files";
+const DB_VERSION = 1;
+
+export class BrowserFileSystemProvider implements FileSystemProvider {
+  readonly id = "browser";
+  private readonly dbName: string;
+
+  constructor(dbName: string = DEFAULT_DB) {
+    this.dbName = dbName;
+  }
+
+  private openDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      if (typeof indexedDB === "undefined") {
+        reject(new Error("IndexedDB is not available in this environment"));
+        return;
+      }
+      const req = indexedDB.open(this.dbName, DB_VERSION);
+      req.onupgradeneeded = () => {
+        if (!req.result.objectStoreNames.contains(STORE)) {
+          req.result.createObjectStore(STORE, { keyPath: "path" });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async getRecord(path: string): Promise<StoredFile | undefined> {
+    const db = await this.openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, "readonly");
+      const req = tx.objectStore(STORE).get(path);
+      req.onsuccess = () =>
+        resolve(req.result as StoredFile | undefined);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async allRecords(): Promise<StoredFile[]> {
+    const db = await this.openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, "readonly");
+      const req = tx.objectStore(STORE).getAll();
+      req.onsuccess = () => resolve((req.result as StoredFile[]) ?? []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async readFile(path: string): Promise<string> {
+    const key = normalizePath(path);
+    const rec = await this.getRecord(key);
+    if (!rec) throw new FileNotFoundError(key);
+    return rec.content;
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    const key = normalizePath(path);
+    const db = await this.openDb();
+    const record: StoredFile = {
+      path: key,
+      content,
+      size: content.length,
+      mtime: Date.now(),
+    };
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put(record);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async delete(path: string): Promise<void> {
+    const key = normalizePath(path);
+    const db = await this.openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).delete(key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  async exists(path: string): Promise<boolean> {
+    const key = normalizePath(path);
+    if (await this.getRecord(key)) return true;
+    // Treat as an (implicit) directory if any file lives beneath it.
+    const prefix = key === "" ? "" : `${key}/`;
+    const all = await this.allRecords();
+    return all.some((r) => r.path.startsWith(prefix) && r.path !== key);
+  }
+
+  async list(dir: string): Promise<FileStat[]> {
+    const base = normalizePath(dir);
+    const prefix = base === "" ? "" : `${base}/`;
+    const all = await this.allRecords();
+    const seen = new Map<string, FileStat>();
+
+    for (const rec of all) {
+      if (!rec.path.startsWith(prefix)) continue;
+      const rest = rec.path.slice(prefix.length);
+      if (rest === "") continue;
+      const slash = rest.indexOf("/");
+      if (slash === -1) {
+        // Direct file child.
+        seen.set(rec.path, {
+          path: rec.path,
+          isDirectory: false,
+          size: rec.size,
+          mtime: rec.mtime,
+        });
+      } else {
+        // Immediate subdirectory.
+        const childDir = `${prefix}${rest.slice(0, slash)}`;
+        if (!seen.has(childDir)) {
+          seen.set(childDir, { path: childDir, isDirectory: true, size: 0 });
+        }
+      }
+    }
+    return [...seen.values()];
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const key = normalizePath(path);
+    const rec = await this.getRecord(key);
+    if (rec) {
+      return {
+        path: key,
+        isDirectory: false,
+        size: rec.size,
+        mtime: rec.mtime,
+      };
+    }
+    if (await this.exists(key)) {
+      return { path: key, isDirectory: true, size: 0 };
+    }
+    throw new FileNotFoundError(key);
+  }
+
+  /** Lightweight existence check used by `basename`-derived display logic. */
+  displayName(path: string): string {
+    return basename(path);
+  }
+}

--- a/ide/src/lib/fs/adapters/GitHubFileSystemProvider.ts
+++ b/ide/src/lib/fs/adapters/GitHubFileSystemProvider.ts
@@ -1,0 +1,191 @@
+/**
+ * Issue #882 — Remote GitHub adapter for {@link FileSystemProvider}.
+ *
+ * Backs the workspace with a GitHub repository via the REST Contents API, so a
+ * project can be opened straight from (and saved back to) a repo. Reads decode
+ * base64 blob content; writes create-or-update a file with its current blob
+ * SHA. The `fetch` implementation is injectable for deterministic testing.
+ */
+import {
+  FileNotFoundError,
+  type FileStat,
+  type FileSystemProvider,
+  normalizePath,
+} from "../FileSystemProvider";
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+export interface GitHubProviderOptions {
+  owner: string;
+  repo: string;
+  /** Branch to read/write. Defaults to "main". */
+  branch?: string;
+  /** Personal access token for authenticated / write access. */
+  token?: string;
+  /** Injectable fetch (defaults to global fetch). */
+  fetchImpl?: FetchLike;
+  /** Override the API base (defaults to https://api.github.com). */
+  apiBase?: string;
+}
+
+interface ContentsEntry {
+  type: "file" | "dir";
+  name: string;
+  path: string;
+  size: number;
+  sha: string;
+  content?: string;
+  encoding?: string;
+}
+
+export class GitHubFileSystemProvider implements FileSystemProvider {
+  readonly id = "github";
+  private readonly owner: string;
+  private readonly repo: string;
+  private readonly branch: string;
+  private readonly token?: string;
+  private readonly fetchImpl: FetchLike;
+  private readonly apiBase: string;
+
+  constructor(opts: GitHubProviderOptions) {
+    this.owner = opts.owner;
+    this.repo = opts.repo;
+    this.branch = opts.branch ?? "main";
+    this.token = opts.token;
+    this.apiBase = opts.apiBase ?? "https://api.github.com";
+    const fallback = (globalThis as { fetch?: FetchLike }).fetch;
+    const impl = opts.fetchImpl ?? fallback;
+    if (!impl) throw new Error("No fetch implementation available");
+    this.fetchImpl = impl;
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (this.token) h.Authorization = `Bearer ${this.token}`;
+    return h;
+  }
+
+  private contentsUrl(path: string): string {
+    const p = normalizePath(path);
+    return `${this.apiBase}/repos/${this.owner}/${this.repo}/contents/${p}?ref=${encodeURIComponent(this.branch)}`;
+  }
+
+  private async getEntry(path: string): Promise<ContentsEntry | ContentsEntry[] | null> {
+    const res = await this.fetchImpl(this.contentsUrl(path), {
+      headers: this.headers(),
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`GitHub API error (${res.status}) for ${normalizePath(path)}`);
+    }
+    return (await res.json()) as ContentsEntry | ContentsEntry[];
+  }
+
+  async readFile(path: string): Promise<string> {
+    const entry = await this.getEntry(path);
+    if (!entry || Array.isArray(entry) || entry.type !== "file") {
+      throw new FileNotFoundError(normalizePath(path));
+    }
+    if (entry.encoding === "base64" && entry.content !== undefined) {
+      // atob is available in browsers and modern Node; fall back to Buffer.
+      const b64 = entry.content.replace(/\n/g, "");
+      if (typeof atob === "function") return atob(b64);
+      return Buffer.from(b64, "base64").toString("utf-8");
+    }
+    return entry.content ?? "";
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    const p = normalizePath(path);
+    const existing = await this.getEntry(p);
+    const sha =
+      existing && !Array.isArray(existing) ? existing.sha : undefined;
+    const encoded =
+      typeof btoa === "function"
+        ? btoa(content)
+        : Buffer.from(content, "utf-8").toString("base64");
+
+    const res = await this.fetchImpl(
+      `${this.apiBase}/repos/${this.owner}/${this.repo}/contents/${p}`,
+      {
+        method: "PUT",
+        headers: { ...this.headers(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: `Update ${p}`,
+          content: encoded,
+          branch: this.branch,
+          ...(sha ? { sha } : {}),
+        }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`GitHub write failed (${res.status}) for ${p}`);
+    }
+  }
+
+  async delete(path: string): Promise<void> {
+    const p = normalizePath(path);
+    const existing = await this.getEntry(p);
+    if (!existing || Array.isArray(existing)) return; // nothing to delete
+    const res = await this.fetchImpl(
+      `${this.apiBase}/repos/${this.owner}/${this.repo}/contents/${p}`,
+      {
+        method: "DELETE",
+        headers: { ...this.headers(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: `Delete ${p}`,
+          sha: existing.sha,
+          branch: this.branch,
+        }),
+      },
+    );
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`GitHub delete failed (${res.status}) for ${p}`);
+    }
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return (await this.getEntry(path)) !== null;
+  }
+
+  async list(dir: string): Promise<FileStat[]> {
+    const entry = await this.getEntry(dir);
+    if (!entry) return [];
+    if (!Array.isArray(entry)) {
+      // A file path was passed where a directory was expected.
+      return [];
+    }
+    return entry.map((e) => ({
+      path: e.path,
+      isDirectory: e.type === "dir",
+      size: e.size,
+    }));
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const entry = await this.getEntry(path);
+    if (!entry) throw new FileNotFoundError(normalizePath(path));
+    if (Array.isArray(entry)) {
+      return { path: normalizePath(path), isDirectory: true, size: 0 };
+    }
+    return {
+      path: entry.path,
+      isDirectory: entry.type === "dir",
+      size: entry.size,
+    };
+  }
+}

--- a/ide/src/lib/fs/adapters/LocalFileSystemProvider.ts
+++ b/ide/src/lib/fs/adapters/LocalFileSystemProvider.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #882 — Local (Node `fs`) adapter for {@link FileSystemProvider}.
+ *
+ * Rooted at a real directory on disk; all provider paths are resolved relative
+ * to that root. Used by the desktop build and server-side API routes that today
+ * call `node:fs` directly. The root containment check guards against `..`
+ * traversal escaping the workspace.
+ */
+import * as nodeFs from "node:fs/promises";
+import * as nodePath from "node:path";
+import {
+  FileNotFoundError,
+  type FileStat,
+  type FileSystemProvider,
+  normalizePath,
+} from "../FileSystemProvider";
+
+export class LocalFileSystemProvider implements FileSystemProvider {
+  readonly id = "local";
+  private readonly root: string;
+  private readonly fs: typeof nodeFs;
+
+  /**
+   * @param root  Absolute directory that bounds this provider.
+   * @param fsImpl Injectable fs implementation (defaults to node:fs/promises),
+   *               primarily to allow deterministic unit testing.
+   */
+  constructor(root: string, fsImpl: typeof nodeFs = nodeFs) {
+    this.root = root;
+    this.fs = fsImpl;
+  }
+
+  /** Resolve a provider path to an absolute on-disk path inside the root. */
+  private resolve(path: string): string {
+    const normalized = normalizePath(path);
+    return normalized === ""
+      ? this.root
+      : nodePath.join(this.root, normalized);
+  }
+
+  async readFile(path: string): Promise<string> {
+    try {
+      return await this.fs.readFile(this.resolve(path), "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new FileNotFoundError(normalizePath(path));
+      }
+      throw err;
+    }
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    const abs = this.resolve(path);
+    await this.fs.mkdir(nodePath.dirname(abs), { recursive: true });
+    await this.fs.writeFile(abs, content, "utf-8");
+  }
+
+  async delete(path: string): Promise<void> {
+    try {
+      await this.fs.rm(this.resolve(path), { recursive: true, force: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      await this.fs.stat(this.resolve(path));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async list(dir: string): Promise<FileStat[]> {
+    const abs = this.resolve(dir);
+    let entries: Array<{ name: string; isDirectory(): boolean }>;
+    try {
+      entries = await this.fs.readdir(abs, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const base = normalizePath(dir);
+    const prefix = base === "" ? "" : `${base}/`;
+    const results: FileStat[] = [];
+    for (const entry of entries) {
+      const childPath = `${prefix}${entry.name}`;
+      if (entry.isDirectory()) {
+        results.push({ path: childPath, isDirectory: true, size: 0 });
+      } else {
+        const st = await this.fs.stat(nodePath.join(abs, entry.name));
+        results.push({
+          path: childPath,
+          isDirectory: false,
+          size: st.size,
+          mtime: st.mtimeMs,
+        });
+      }
+    }
+    return results;
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    try {
+      const st = await this.fs.stat(this.resolve(path));
+      return {
+        path: normalizePath(path),
+        isDirectory: st.isDirectory(),
+        size: st.isDirectory() ? 0 : st.size,
+        mtime: st.mtimeMs,
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new FileNotFoundError(normalizePath(path));
+      }
+      throw err;
+    }
+  }
+}

--- a/ide/src/lib/fs/index.ts
+++ b/ide/src/lib/fs/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Issue #882 — Public surface for the abstract file-system layer.
+ *
+ * Import the interface and adapters from here rather than reaching into
+ * individual files, e.g.:
+ *   import { type FileSystemProvider, LocalFileSystemProvider } from "@/lib/fs";
+ */
+export {
+  type FileSystemProvider,
+  type FileStat,
+  FileNotFoundError,
+  normalizePath,
+  dirname,
+  basename,
+} from "./FileSystemProvider";
+
+export { BrowserFileSystemProvider } from "./adapters/BrowserFileSystemProvider";
+export { LocalFileSystemProvider } from "./adapters/LocalFileSystemProvider";
+export {
+  GitHubFileSystemProvider,
+  type GitHubProviderOptions,
+} from "./adapters/GitHubFileSystemProvider";


### PR DESCRIPTION
## Summary

Introduces a unified `FileSystemProvider` interface and three concrete adapters so the IDE's file operations compile against an abstraction rather than reaching for browser storage APIs directly. All changes are confined to the `ide/` directory.

Closes #882

## Deliverables

- **`ide/src/lib/fs/FileSystemProvider.ts`** — the unified interface (`readFile`, `writeFile`, `delete`, `exists`, `list`, `stat`) plus a `FileStat` type, a `FileNotFoundError`, and path helpers (`normalizePath` / `dirname` / `basename`) with `..`-traversal protection.
- **Adapters** (`ide/src/lib/fs/adapters/`):
  - `BrowserFileSystemProvider` — IndexedDB-backed, for in-browser workspaces (replaces ad-hoc localStorage/IndexedDB access). Directories are implicit from stored paths.
  - `LocalFileSystemProvider` — Node `fs` rooted at a directory, with root-containment checks; `fs` impl is injectable for testing.
  - `GitHubFileSystemProvider` — remote GitHub repo via the REST Contents API (base64 blob decode on read; create-or-update with blob sha on write); `fetch` is injectable.
- **`ide/src/lib/fs/index.ts`** — barrel export for clean imports.

Each adapter implements the identical `FileSystemProvider` contract, so workspace/editor code can be written once and pointed at browser, local, or remote storage.

## Design notes

- Paths are normalised to POSIX form internally; a leading slash is optional and equivalent to none.
- External dependencies (node `fs`, `fetch`) are injected via constructors, keeping the adapters unit-testable without real I/O.
- Aligns with the existing `ide/src/lib/fs/UniversalResolver.ts` conventions (same folder, IndexedDB usage style, vitest tests under `__tests__/`).

## Verified terminal output

This is a TypeScript library change (no UI to screenshot), so here is the test + typecheck output:

```
# Unit tests (vitest) — interface helpers + all three adapters
 Test Files  1 passed (1)
      Tests  25 passed (25)

# Typecheck — no errors introduced in src/lib/fs
$ npx tsc --noEmit  ->  0 errors in src/lib/fs/**
# (one pre-existing, unrelated error in src/lib/test/FuzzingEngine.ts exists on main)
```

The 25 tests cover: path normalization + traversal guards; Browser adapter read/write/delete/exists/list/stat with implicit directories; Local adapter via an injected in-memory fs (incl. root-escape rejection); GitHub adapter via injected fetch (base64 read, 404 → FileNotFoundError, create-without-sha, update-with-sha, list, exists); and a cross-adapter contract test asserting all three implement the full interface.

## Acceptance criteria

- [x] Unified `FileSystemProvider` interface
- [x] Adapters for browser storage, local files, and remote repositories
- [x] Deliverable `src/lib/fs/FileSystemProvider.ts` present
- [x] All work confined to `ide/`