### PR TITLE
feat: editor visual settings (#928) + soroban-sdk deprecation checker (#933)

### DIFF
--- a/extension/scripts/check-deprecation.js
+++ b/extension/scripts/check-deprecation.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Verification harness for the soroban-sdk DeprecationChecker core (issue #933).
+ *
+ * Exercises the pure parsing + comparison logic against representative
+ * Cargo.toml fixtures and prints PASS/FAIL for each, with a non-zero exit on any
+ * failure. This is the "verified terminal output" the issue requires; it needs
+ * no VS Code host (the vscode-dependent class is exercised in the editor).
+ *
+ * Run: node scripts/check-deprecation.js   (after `npm run compile`)
+ */
+const {
+  findSorobanSdkVersion,
+  checkDeprecation,
+  parseSemVer,
+  LATEST_KNOWN_SOROBAN_SDK,
+} = require('../out/services/DeprecationChecker.core.js');
+
+let failures = 0;
+function assert(name, cond) {
+  const status = cond ? 'PASS' : 'FAIL';
+  if (!cond) failures++;
+  console.log(`  [${status}] ${name}`);
+}
+
+console.log('soroban-sdk DeprecationChecker — verification');
+console.log(`latest known (offline floor): ${LATEST_KNOWN_SOROBAN_SDK}\n`);
+
+// 1. Simple string dependency, outdated.
+const m1 = findSorobanSdkVersion('soroban-sdk = "20.0.0"\n');
+assert('parses simple string dependency', m1 && m1.raw === '20.0.0');
+assert('classifies 20.0.0 as deprecated', checkDeprecation(m1.version).level === 'deprecated');
+
+// 2. Table form with features, deprecated.
+const m2 = findSorobanSdkVersion(
+  '[dependencies]\nsoroban-sdk = { version = "19.1.0", features = ["testutils"] }\n',
+);
+assert('parses table-form dependency', m2 && m2.raw === '19.1.0');
+assert('classifies 19.1.0 as deprecated', checkDeprecation(m2.version).level === 'deprecated');
+
+// 3. Caret requirement just below latest → outdated (not deprecated).
+const m3 = findSorobanSdkVersion('soroban-sdk = "^21.5.0"\n');
+assert('strips caret prefix', m3 && m3.version.major === 21 && m3.version.minor === 5);
+assert('classifies 21.5.0 as outdated', checkDeprecation(m3.version).level === 'outdated');
+
+// 4. Up-to-date version → ok.
+const m4 = findSorobanSdkVersion(`soroban-sdk = "${LATEST_KNOWN_SOROBAN_SDK}"\n`);
+assert('classifies latest as ok', checkDeprecation(m4.version).level === 'ok');
+
+// 5. No soroban-sdk dependency → null (nothing to warn).
+assert('returns null when soroban-sdk absent', findSorobanSdkVersion('serde = "1"\n') === null);
+
+// 6. Git/path dependency (no pinned version) → null.
+assert(
+  'returns null for git dependency',
+  findSorobanSdkVersion('soroban-sdk = { git = "https://github.com/stellar/rs-soroban-sdk" }\n') === null,
+);
+
+// 7. Line/column tracking points at the version string.
+const lined = '[dependencies]\nfoo = "1"\nsoroban-sdk = "18.0.0"\n';
+const m7 = findSorobanSdkVersion(lined);
+assert('reports correct line index', m7 && m7.line === 2);
+assert('reports version start column', m7 && lined.split('\n')[2].slice(m7.startCol, m7.endCol) === '18.0.0');
+
+// 8. parseSemVer tolerates partial versions.
+const pv = parseSemVer('20');
+assert('parseSemVer fills missing minor/patch', pv.major === 20 && pv.minor === 0 && pv.patch === 0);
+
+console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,6 +19,7 @@ import { registerOpenInWebIDECommand } from './commands/OpenInWebIDE';
 import { getSharedOutputChannel } from './utils/outputChannel';
 import { SorobanCliService } from './services/sorobanCliService';
 import { SorobanLinterService } from './services/LinterService';
+import { DeprecationChecker } from './services/DeprecationChecker';
 import { HealthAlertsService } from './services/HealthAlerts';
 import { getLatencyMonitor } from './ui/networkStatusBar';
 import { registerSorobanCompletionProvider } from './providers/SorobanCompletionProvider';
@@ -76,6 +77,11 @@ export async function activate(context: vscode.ExtensionContext) {
         const linter = new SorobanLinterService();
         linter.register(context);
         context.subscriptions.push(linter);
+
+        // Soroban SDK deprecation warnings on Cargo.toml manifests (issue #933).
+        const deprecationChecker = new DeprecationChecker();
+        deprecationChecker.register(context);
+        context.subscriptions.push(deprecationChecker);
 
         const simulateCommand = vscode.commands.registerCommand(
             'stellarSuite.simulateTransaction',

--- a/extension/src/services/DeprecationChecker.core.ts
+++ b/extension/src/services/DeprecationChecker.core.ts
@@ -1,0 +1,157 @@
+/**
+ * Issue #933 — Soroban SDK deprecation: pure parsing + comparison core.
+ *
+ * This module deliberately has NO `vscode` import so it can be unit-tested and
+ * run from a plain Node script (scripts/check-deprecation.js). The VS Code
+ * diagnostic integration lives in DeprecationChecker.ts and consumes this core.
+ */
+
+/**
+ * Latest known soroban-sdk version used as the offline comparison floor.
+ * Bump this as the SDK advances; it is the fallback when crates.io is unreachable.
+ */
+export const LATEST_KNOWN_SOROBAN_SDK = '22.0.0';
+
+/**
+ * The minimum version below which we actively warn (Warning severity). Versions
+ * at or above `LATEST_KNOWN` are never flagged; versions in between are surfaced
+ * as informational "outdated" notices.
+ */
+export const DEPRECATED_BELOW_SOROBAN_SDK = '21.0.0';
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export interface SdkVersionMatch {
+  /** The raw version requirement string as written in Cargo.toml, e.g. "^20.0.0". */
+  raw: string;
+  /** Parsed semver (caret/tilde/`=` prefixes and quotes stripped). */
+  version: SemVer;
+  /** 0-based line index within the manifest where the dependency was declared. */
+  line: number;
+  /** Column range [start, end) of the version string on that line. */
+  startCol: number;
+  endCol: number;
+}
+
+/** Parse a semver-ish string ("^20.1", "=20.0.3", "20") into a SemVer. */
+export function parseSemVer(input: string): SemVer | null {
+  const cleaned = input.trim().replace(/^[\^~=>=<\s]*/, '').replace(/['"]/g, '');
+  const match = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(cleaned);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2] ?? 0),
+    patch: Number(match[3] ?? 0),
+  };
+}
+
+/** Compare two SemVers: -1 if a<b, 0 if equal, 1 if a>b. */
+export function compareSemVer(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Locate the `soroban-sdk` dependency version in a Cargo.toml manifest.
+ *
+ * Handles both forms:
+ *   soroban-sdk = "20.0.0"
+ *   soroban-sdk = { version = "20.0.0", features = [...] }
+ *
+ * Returns `null` when soroban-sdk is not a dependency or has no pinned version
+ * (e.g. a git/path dependency, which we cannot meaningfully compare).
+ */
+export function findSorobanSdkVersion(manifest: string): SdkVersionMatch | null {
+  const lines = manifest.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Only consider a dependency declaration line for soroban-sdk.
+    if (!/^\s*"?soroban-sdk"?\s*=/.test(line)) continue;
+
+    // Find the first quoted version string on the line.
+    const versionMatch = /version\s*=\s*"([^"]+)"|=\s*"([^"]+)"/.exec(line);
+    const raw = versionMatch?.[1] ?? versionMatch?.[2];
+    if (!raw) return null; // git/path dependency or unparseable
+
+    const version = parseSemVer(raw);
+    if (!version) return null;
+
+    const startCol = line.indexOf(raw);
+    return {
+      raw,
+      version,
+      line: i,
+      startCol,
+      endCol: startCol + raw.length,
+    };
+  }
+  return null;
+}
+
+export type DeprecationLevel = 'ok' | 'outdated' | 'deprecated';
+
+export interface DeprecationResult {
+  level: DeprecationLevel;
+  current: SemVer;
+  latest: string;
+  message: string;
+}
+
+/**
+ * Classify a pinned soroban-sdk version against the latest known release.
+ *   - `deprecated` — below DEPRECATED_BELOW_SOROBAN_SDK (Warning).
+ *   - `outdated`   — below latest but not deprecated (Information).
+ *   - `ok`         — at or above latest known.
+ */
+export function checkDeprecation(
+  current: SemVer,
+  latest: string = LATEST_KNOWN_SOROBAN_SDK,
+): DeprecationResult {
+  const latestSemVer = parseSemVer(latest)!;
+  const deprecatedBelow = parseSemVer(DEPRECATED_BELOW_SOROBAN_SDK)!;
+  const cur = `${current.major}.${current.minor}.${current.patch}`;
+
+  if (compareSemVer(current, latestSemVer) >= 0) {
+    return { level: 'ok', current, latest, message: `soroban-sdk ${cur} is up to date.` };
+  }
+  if (compareSemVer(current, deprecatedBelow) < 0) {
+    return {
+      level: 'deprecated',
+      current,
+      latest,
+      message: `soroban-sdk ${cur} is deprecated. Upgrade to ${latest} for security and performance fixes.`,
+    };
+  }
+  return {
+    level: 'outdated',
+    current,
+    latest,
+    message: `soroban-sdk ${cur} is outdated. The latest release is ${latest}.`,
+  };
+}
+
+/**
+ * Fetch the latest soroban-sdk version from crates.io, falling back to the
+ * hardcoded {@link LATEST_KNOWN_SOROBAN_SDK} on any error (offline support).
+ * `fetchImpl` is injectable for testing.
+ */
+export async function fetchLatestSorobanSdk(
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  try {
+    const res = await fetchImpl('https://crates.io/api/v1/crates/soroban-sdk', {
+      headers: { Accept: 'application/json', 'User-Agent': 'stellar-suite-extension' },
+    });
+    if (!res.ok) return LATEST_KNOWN_SOROBAN_SDK;
+    const data = (await res.json()) as { crate?: { max_stable_version?: string } };
+    return data.crate?.max_stable_version ?? LATEST_KNOWN_SOROBAN_SDK;
+  } catch {
+    return LATEST_KNOWN_SOROBAN_SDK;
+  }
+}

--- a/extension/src/services/DeprecationChecker.ts
+++ b/extension/src/services/DeprecationChecker.ts
@@ -1,0 +1,102 @@
+import * as vscode from 'vscode';
+import {
+  LATEST_KNOWN_SOROBAN_SDK,
+  checkDeprecation,
+  fetchLatestSorobanSdk,
+  findSorobanSdkVersion,
+} from './DeprecationChecker.core';
+
+/**
+ * Issue #933 — Soroban SDK Deprecation Warning System (VS Code integration).
+ *
+ * Watches Cargo.toml manifests and publishes a Problems-panel warning when the
+ * pinned `soroban-sdk` version is older than the latest known release. All the
+ * parsing/comparison logic lives in the vscode-free ./DeprecationChecker.core,
+ * which is unit-tested by scripts/check-deprecation.js.
+ */
+
+// Re-export the pure core so callers can `import { ... } from './DeprecationChecker'`.
+export * from './DeprecationChecker.core';
+
+export const DEPRECATION_SOURCE = 'soroban-sdk-deprecation';
+
+export class DeprecationChecker implements vscode.Disposable {
+  private collection: vscode.DiagnosticCollection;
+  private subscriptions: vscode.Disposable[] = [];
+  private latest: string = LATEST_KNOWN_SOROBAN_SDK;
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection('soroban-sdk-deprecation');
+  }
+
+  register(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(this.collection);
+
+    this.subscriptions.push(
+      vscode.workspace.onDidOpenTextDocument(doc => this.check(doc)),
+      vscode.workspace.onDidSaveTextDocument(doc => this.check(doc)),
+      vscode.workspace.onDidCloseTextDocument(doc => this.collection.delete(doc.uri)),
+    );
+    for (const sub of this.subscriptions) {
+      context.subscriptions.push(sub);
+    }
+
+    // Best-effort refresh of the latest version; offline fallback otherwise.
+    void fetchLatestSorobanSdk().then(v => {
+      this.latest = v;
+      for (const doc of vscode.workspace.textDocuments) {
+        this.check(doc);
+      }
+    });
+
+    for (const doc of vscode.workspace.textDocuments) {
+      this.check(doc);
+    }
+  }
+
+  /** Returns true when the document is a Cargo.toml manifest. */
+  private isManifest(document: vscode.TextDocument): boolean {
+    return /(^|[\\/])Cargo\.toml$/.test(document.fileName) || document.languageId === 'toml';
+  }
+
+  private check(document: vscode.TextDocument): void {
+    if (!this.isManifest(document)) {
+      return;
+    }
+    const match = findSorobanSdkVersion(document.getText());
+    if (!match) {
+      this.collection.delete(document.uri);
+      return;
+    }
+
+    const result = checkDeprecation(match.version, this.latest);
+    if (result.level === 'ok') {
+      this.collection.delete(document.uri);
+      return;
+    }
+
+    const range = new vscode.Range(
+      new vscode.Position(match.line, match.startCol),
+      new vscode.Position(match.line, match.endCol),
+    );
+    const severity =
+      result.level === 'deprecated'
+        ? vscode.DiagnosticSeverity.Warning
+        : vscode.DiagnosticSeverity.Information;
+
+    const diagnostic = new vscode.Diagnostic(range, result.message, severity);
+    diagnostic.source = DEPRECATION_SOURCE;
+    diagnostic.code =
+      result.level === 'deprecated' ? 'soroban-sdk-deprecated' : 'soroban-sdk-outdated';
+
+    this.collection.set(document.uri, [diagnostic]);
+  }
+
+  dispose(): void {
+    for (const sub of this.subscriptions) {
+      sub.dispose();
+    }
+    this.subscriptions = [];
+    this.collection.dispose();
+  }
+}

--- a/ide/src/components/ide/CodeEditor.tsx
+++ b/ide/src/components/ide/CodeEditor.tsx
@@ -149,8 +149,14 @@ useEffect(() => {
     }
   }, [activeFile?.content, config.enabled, activeFileId, analyze]);
 
-  // User settings (font size and theme)
-  const { fontSize, theme: currentTheme } = useUserSettingsStore();
+  // User settings (font size, theme, and editor visual preferences — issue #928)
+  const {
+    fontSize,
+    theme: currentTheme,
+    editorMinimap,
+    editorIndentGuides,
+    editorFontLigatures,
+  } = useUserSettingsStore();
 
   const handleEditorChange: OnChange = (value) => {
     if (value !== undefined) {
@@ -699,7 +705,10 @@ useEffect(() => {
             options={{
               fontSize: fontSize,
               readOnly: mode === "recipient",
-              minimap: { enabled: false },
+              // Editor visual preferences (issue #928) — driven by UserSettingsStore.
+              minimap: { enabled: editorMinimap },
+              guides: { indentation: editorIndentGuides },
+              fontLigatures: editorFontLigatures,
               scrollBeyondLastLine: false,
               automaticLayout: true,
               tabSize: 4,

--- a/ide/src/components/ide/SettingsModal.tsx
+++ b/ide/src/components/ide/SettingsModal.tsx
@@ -18,6 +18,7 @@ import { ResourceUsageDashboard } from "@/components/settings/ResourceUsageDashb
 import { ThemeEditor } from "@/components/settings/ThemeEditor";
 import { Diagnostics } from "@/components/settings/Diagnostics";
 import { TerminalSettings } from "@/components/settings/TerminalSettings";
+import { EditorVisualSettings } from "@/components/settings/EditorVisualSettings";
 import { KeyboardShortcutEditor } from "@/components/settings/KeyboardShortcutEditor";
 import { useTranslation } from "react-i18next";
 import {
@@ -202,6 +203,8 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 className="data-[state=checked]:bg-amber-600"
               />
             </div>
+
+            <EditorVisualSettings />
 
             <TerminalSettings />
           </TabsContent>

--- a/ide/src/components/settings/EditorVisualSettings.tsx
+++ b/ide/src/components/settings/EditorVisualSettings.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Issue #928 — Monaco minimap & guide settings.
+ *
+ * Visual toggles in Settings for editor readability features: the code minimap,
+ * indentation guides, and font ligatures. Each toggle persists to the
+ * UserSettingsStore (zustand + localStorage), and CodeEditor reads these values
+ * to configure Monaco, so changes apply fluidly without a reload.
+ */
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useUserSettingsStore } from "@/store/useUserSettingsStore";
+
+interface ToggleRowProps {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+function ToggleRow({ id, label, description, checked, onCheckedChange }: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="space-y-0.5">
+        <Label htmlFor={id} className="text-sm font-medium">
+          {label}
+        </Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}
+
+export function EditorVisualSettings() {
+  const {
+    editorMinimap,
+    editorIndentGuides,
+    editorFontLigatures,
+    setEditorMinimap,
+    setEditorIndentGuides,
+    setEditorFontLigatures,
+  } = useUserSettingsStore();
+
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-card/40 p-4">
+      <Label className="text-sm font-semibold">Editor Appearance</Label>
+
+      <div className="space-y-4">
+        <ToggleRow
+          id="editor-minimap"
+          label="Minimap"
+          description="Show the code overview minimap on the right edge of the editor."
+          checked={editorMinimap}
+          onCheckedChange={setEditorMinimap}
+        />
+        <ToggleRow
+          id="editor-indent-guides"
+          label="Indent guides"
+          description="Render vertical guide lines for indentation levels."
+          checked={editorIndentGuides}
+          onCheckedChange={setEditorIndentGuides}
+        />
+        <ToggleRow
+          id="editor-font-ligatures"
+          label="Font ligatures"
+          description="Combine character sequences like => and != into single glyphs."
+          checked={editorFontLigatures}
+          onCheckedChange={setEditorFontLigatures}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ide/src/store/__tests__/editorVisualSettings.test.ts
+++ b/ide/src/store/__tests__/editorVisualSettings.test.ts
@@ -1,0 +1,62 @@
+/**
+ * src/store/__tests__/editorVisualSettings.test.ts
+ * ──────────────────────────────────────────────────────────────
+ * Unit tests for the editor visual settings added in issue #928:
+ * minimap, indent guides, and font ligatures toggles persisted to
+ * the UserSettingsStore.
+ * ──────────────────────────────────────────────────────────────
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUserSettingsStore } from "../useUserSettingsStore";
+
+// Capture the pristine defaults so each test starts from a known state.
+const DEFAULTS = {
+  editorMinimap: useUserSettingsStore.getState().editorMinimap,
+  editorIndentGuides: useUserSettingsStore.getState().editorIndentGuides,
+  editorFontLigatures: useUserSettingsStore.getState().editorFontLigatures,
+};
+
+beforeEach(() => {
+  useUserSettingsStore.setState({ ...DEFAULTS });
+});
+
+describe("editor visual settings defaults (#928)", () => {
+  it("defaults the minimap off", () => {
+    expect(useUserSettingsStore.getState().editorMinimap).toBe(false);
+  });
+
+  it("defaults indent guides and font ligatures on", () => {
+    const s = useUserSettingsStore.getState();
+    expect(s.editorIndentGuides).toBe(true);
+    expect(s.editorFontLigatures).toBe(true);
+  });
+});
+
+describe("editor visual setters (#928)", () => {
+  it("toggles the minimap and stores the value", () => {
+    useUserSettingsStore.getState().setEditorMinimap(true);
+    expect(useUserSettingsStore.getState().editorMinimap).toBe(true);
+    useUserSettingsStore.getState().setEditorMinimap(false);
+    expect(useUserSettingsStore.getState().editorMinimap).toBe(false);
+  });
+
+  it("toggles indent guides", () => {
+    useUserSettingsStore.getState().setEditorIndentGuides(false);
+    expect(useUserSettingsStore.getState().editorIndentGuides).toBe(false);
+  });
+
+  it("toggles font ligatures", () => {
+    useUserSettingsStore.getState().setEditorFontLigatures(false);
+    expect(useUserSettingsStore.getState().editorFontLigatures).toBe(false);
+  });
+
+  it("persists under the 'user-settings' storage key", () => {
+    // The store is wrapped in zustand's persist middleware; updating a value
+    // writes the whole settings slice to localStorage under this key.
+    useUserSettingsStore.getState().setEditorMinimap(true);
+    const raw = window.localStorage.getItem("user-settings");
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.state.editorMinimap).toBe(true);
+  });
+});

--- a/ide/src/store/useUserSettingsStore.ts
+++ b/ide/src/store/useUserSettingsStore.ts
@@ -189,6 +189,13 @@ interface UserSettingsState {
   terminalTheme: TerminalTheme;
   terminalFontFamily: string;
   terminalFontSize: number;
+  // ── Editor visual preferences (issue #928) ──────────────────────────────────
+  /** Show the Monaco code minimap on the right edge of the editor. */
+  editorMinimap: boolean;
+  /** Render vertical indentation guide lines. */
+  editorIndentGuides: boolean;
+  /** Enable programming font ligatures (e.g. => rendered as a glyph). */
+  editorFontLigatures: boolean;
   setTheme: (theme: Theme) => void;
   setLanguage: (language: Language) => void;
   setBrandTheme: (brandTheme: BrandThemeTokens) => void;
@@ -198,6 +205,9 @@ interface UserSettingsState {
   setTerminalTheme: (terminalTheme: TerminalTheme) => void;
   setTerminalFontFamily: (fontFamily: string) => void;
   setTerminalFontSize: (fontSize: number) => void;
+  setEditorMinimap: (enabled: boolean) => void;
+  setEditorIndentGuides: (enabled: boolean) => void;
+  setEditorFontLigatures: (enabled: boolean) => void;
 }
 
 export const useUserSettingsStore = create<UserSettingsState>()(
@@ -212,6 +222,9 @@ export const useUserSettingsStore = create<UserSettingsState>()(
       terminalTheme: 'default',
       terminalFontFamily: '"JetBrains Mono", "Cascadia Code", "Fira Code", Menlo, monospace',
       terminalFontSize: 12,
+      editorMinimap: false,
+      editorIndentGuides: true,
+      editorFontLigatures: true,
       setTheme: (theme) => set({ theme }),
       setLanguage: (language) => set({ language }),
       setBrandTheme: (brandTheme) => {
@@ -224,6 +237,9 @@ export const useUserSettingsStore = create<UserSettingsState>()(
       setTerminalTheme: (terminalTheme) => set({ terminalTheme }),
       setTerminalFontFamily: (terminalFontFamily) => set({ terminalFontFamily }),
       setTerminalFontSize: (terminalFontSize) => set({ terminalFontSize }),
+      setEditorMinimap: (editorMinimap) => set({ editorMinimap }),
+      setEditorIndentGuides: (editorIndentGuides) => set({ editorIndentGuides }),
+      setEditorFontLigatures: (editorFontLigatures) => set({ editorFontLigatures }),
     }),
     {
       name: 'user-settings',


### PR DESCRIPTION
## Summary

Two related editor/extension UX features for the v-next milestone:

Closes #928
Closes #933

## #928 — Monaco minimap & guide settings (`ide/`)

Adds visual toggles in **Settings → Editor** for code-readability features, each persisting to the `UserSettingsStore` (zustand + localStorage).

- **New:** `ide/src/components/settings/EditorVisualSettings.tsx` — minimap, indent-guide, and font-ligature toggles using the existing `Switch` UI.
- `useUserSettingsStore.ts` — adds `editorMinimap` (default off), `editorIndentGuides` (on), `editorFontLigatures` (on) + setters; persisted under the existing `user-settings` key.
- `SettingsModal.tsx` — renders `<EditorVisualSettings />` in the Editor tab.
- `CodeEditor.tsx` — Monaco `options` now read these settings (`minimap.enabled`, `guides.indentation`, `fontLigatures`) so changes apply fluidly.

## #933 — Soroban SDK deprecation warnings (`extension/`)

Parses the `soroban-sdk` version from Cargo.toml manifests and raises a VS Code Problems-panel warning when it's outdated.

- **New:** `extension/src/services/DeprecationChecker.ts` — VS Code integration (DiagnosticCollection over Cargo.toml; Warning for deprecated, Information for outdated).
- **New:** `extension/src/services/DeprecationChecker.core.ts` — pure, `vscode`-free parsing/comparison core (semver parse, manifest scan with line/col tracking, classification). Includes a crates.io latest-version lookup with an **offline hardcoded fallback**.
- `extension.ts` — registers the checker on activation.
- Handles both `soroban-sdk = "x"` and `{ version = "x", features = [...] }` forms; ignores git/path deps.

## Verified terminal output

**#928 — store unit tests (vitest):**
```
$ npx vitest run src/store/__tests__/editorVisualSettings.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

**#933 — deprecation core verification (node):**
```
$ node scripts/check-deprecation.js
soroban-sdk DeprecationChecker — verification
latest known (offline floor): 22.0.0
  [PASS] parses simple string dependency
  [PASS] classifies 20.0.0 as deprecated
  [PASS] parses table-form dependency
  [PASS] classifies 19.1.0 as deprecated
  [PASS] strips caret prefix
  [PASS] classifies 21.5.0 as outdated
  [PASS] classifies latest as ok
  [PASS] returns null when soroban-sdk absent
  [PASS] returns null for git dependency
  [PASS] reports correct line index
  [PASS] reports version start column
  [PASS] parseSemVer fills missing minor/patch
ALL CHECKS PASSED
```

`tsc` is clean for all five new/changed files of mine. (Note: a full `tsc -p ./` on the extension surfaces one **pre-existing** syntax error in `src/services/EventMonitor.ts` that is present on `main` and unrelated to this PR.)

## Acceptance criteria
- [x] #928 — Minimap toggle in Settings modal
- [x] #928 — Indent guide and font ligature toggles persisting to UserSettingsStore
- [x] #933 — Parse soroban-sdk version from workspace manifest files
- [x] #933 — VS Code problem warning highlighting outdated sdk versions